### PR TITLE
Fix nuget publish gating

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -232,6 +232,7 @@ jobs:
                       -c Release
 
             -   name: "Push to NuGet"
+                if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'codex') }}
                 env:
                     NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
                 run: |


### PR DESCRIPTION
## Summary
- only publish nuget package when not running on PR and branch name doesn't contain `codex`

## Testing
- `dotnet --version` *(fails: command not found)*