### PR TITLE
Add tests for World events

### DIFF
--- a/src/UnitTests/EventTests.cs
+++ b/src/UnitTests/EventTests.cs
@@ -1,0 +1,80 @@
+using Box2D;
+using System.Numerics;
+using Xunit;
+
+namespace UnitTests;
+
+public class EventTests
+{
+    [Fact]
+    public void SensorBeginEndEventsRaised()
+    {
+        int beginCount = 0;
+        int endCount = 0;
+
+        World world = World.CreateWorld(new WorldDef());
+        world.SensorBeginTouch += (_, _) => beginCount++;
+        world.SensorEndTouch += (_, _) => endCount++;
+
+        BodyDef staticDef = new() { Type = BodyType.Static };
+        Body sensorBody = world.CreateBody(staticDef);
+
+        ShapeDef sensorShapeDef = new();
+        sensorShapeDef.IsSensor = true;
+        sensorShapeDef.EnableSensorEvents = true;
+        sensorBody.CreateShape(sensorShapeDef, new Circle { Radius = 1f });
+
+        BodyDef dynamicDef = new() { Type = BodyType.Dynamic, Position = new(-2f, 0f) };
+        Body dynamicBody = world.CreateBody(dynamicDef);
+
+        ShapeDef dynamicShapeDef = new() { Density = 1f };
+        dynamicShapeDef.EnableSensorEvents = true;
+        dynamicBody.CreateShape(dynamicShapeDef, new Circle { Radius = 0.5f });
+
+        dynamicBody.LinearVelocity = new Vector2(5f, 0f);
+        for (int i = 0; i < 60; ++i)
+        {
+            world.Step();
+        }
+
+        Assert.True(beginCount > 0, "Sensor begin touch event not raised");
+        Assert.True(endCount > 0, "Sensor end touch event not raised");
+    }
+
+    [Fact]
+    public void ContactBeginEndHitEventsRaised()
+    {
+        int beginCount = 0;
+        int endCount = 0;
+        int hitCount = 0;
+
+        World world = World.CreateWorld(new WorldDef());
+        world.ContactBeginTouch += (_, _) => beginCount++;
+        world.ContactEndTouch += (_, _) => endCount++;
+        world.ContactHit += (_, _) => hitCount++;
+
+        BodyDef bodyDefA = new() { Type = BodyType.Dynamic, Position = new(-2f, 0f) };
+        BodyDef bodyDefB = new() { Type = BodyType.Dynamic, Position = new(2f, 0f) };
+        Body bodyA = world.CreateBody(bodyDefA);
+        Body bodyB = world.CreateBody(bodyDefB);
+
+        ShapeDef shapeDef = new() { Density = 1f };
+        shapeDef.EnableContactEvents = true;
+        shapeDef.EnableHitEvents = true;
+
+        Circle circle = new() { Radius = 0.5f };
+        bodyA.CreateShape(shapeDef, circle);
+        bodyB.CreateShape(shapeDef, circle);
+
+        bodyA.LinearVelocity = new Vector2(5f, 0f);
+        bodyB.LinearVelocity = new Vector2(-5f, 0f);
+        for (int i = 0; i < 120; ++i)
+        {
+            world.Step();
+        }
+
+        Assert.True(beginCount > 0, "Contact begin touch event not raised");
+        Assert.True(hitCount > 0, "Contact hit event not raised");
+        Assert.True(endCount > 0, "Contact end touch event not raised");
+    }
+}

--- a/src/UnitTests/QueryTests.cs
+++ b/src/UnitTests/QueryTests.cs
@@ -1,0 +1,86 @@
+using Box2D;
+using Vec2 = System.Numerics.Vector2;
+using Xunit;
+
+namespace UnitTests;
+
+public class QueryTests
+{
+    [Fact]
+    public void CastRayClosest_HitsDynamicShape()
+    {
+        var world = World.CreateWorld(new WorldDef());
+        var bodyDef = new BodyDef { Type = BodyType.Dynamic, Position = new Vec2(0, 0) };
+        var body = world.CreateBody(bodyDef);
+        var shapeDef = new ShapeDef { Density = 1f };
+        var circle = new Circle { Radius = 1f };
+        var shape = body.CreateShape(shapeDef, circle);
+
+        RayResult result = world.CastRayClosest(new Vec2(-5f, 0f), new Vec2(10f, 0f), new QueryFilter());
+
+        Assert.True(result.Hit, "RayCast should hit the dynamic shape");
+        Assert.Equal(shape, result.Shape);
+        Assert.InRange(result.Fraction, 0f, 1f);
+    }
+
+    [Fact]
+    public void CastRay_CallbackInvoked()
+    {
+        var world = World.CreateWorld(new WorldDef());
+        var bodyDef = new BodyDef { Type = BodyType.Dynamic, Position = new Vec2(0, 0) };
+        var body = world.CreateBody(bodyDef);
+        var shapeDef = new ShapeDef { Density = 1f };
+        body.CreateShape(shapeDef, new Circle { Radius = 0.5f });
+
+        int hits = 0;
+        world.CastRay(new Vec2(-2f, 0f), new Vec2(4f, 0f), new QueryFilter(), (s, p, n, f) =>
+        {
+            hits++;
+            return 0f; // terminate after first hit
+        });
+
+        Assert.Equal(1, hits);
+    }
+
+    [Fact]
+    public void OverlapAABB_FindsShape()
+    {
+        var world = World.CreateWorld(new WorldDef());
+        var bodyDef = new BodyDef { Type = BodyType.Dynamic, Position = new Vec2(1, 1) };
+        var body = world.CreateBody(bodyDef);
+        var shapeDef = new ShapeDef { Density = 1f };
+        var circle = body.CreateShape(shapeDef, new Circle { Radius = 0.5f });
+
+        int count = 0;
+        OverlapResultCallback callback = s =>
+        {
+            count++;
+            return true;
+        };
+
+        world.OverlapAABB(new AABB(new Vec2(0, 0), new Vec2(2, 2)), new QueryFilter(), ref callback);
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void CastShape_DetectsCollision()
+    {
+        var world = World.CreateWorld(new WorldDef());
+        var staticBodyDef = new BodyDef { Type = BodyType.Static, Position = new Vec2(2f, 0f) };
+        var staticBody = world.CreateBody(staticBodyDef);
+        var shapeDef = new ShapeDef();
+        staticBody.CreateShape(shapeDef, new Circle { Radius = 0.5f });
+
+        ShapeProxy proxy = Core.MakeProxy(new Circle { Radius = 0.5f });
+
+        int hits = 0;
+        world.CastShape(proxy, new Vec2(3f, 0f), new QueryFilter(), (s, p, n, f) =>
+        {
+            hits++;
+            return 0f;
+        });
+
+        Assert.True(hits > 0, "CastShape should detect the static body");
+    }
+}


### PR DESCRIPTION
## Summary
- add `EventTests.cs` to verify sensor and contact event callbacks
- add `QueryTests.cs` to cover ray casting, shape casting and overlap queries

## Testing
- `dotnet test --no-build -v minimal` *(fails: `dotnet` not found)*