### PR TITLE
Add event and query tests

### DIFF
--- a/src/UnitTests/EventTests.cs
+++ b/src/UnitTests/EventTests.cs
@@ -1,0 +1,80 @@
+using Box2D;
+using System.Numerics;
+using Xunit;
+
+namespace UnitTests;
+
+public class EventTests
+{
+    [Fact]
+    public void SensorBeginEndEventsRaised()
+    {
+        int beginCount = 0;
+        int endCount = 0;
+
+        World world = World.CreateWorld(new WorldDef());
+        world.SensorBeginTouch += (in SensorBeginTouchEvent _) => beginCount++;
+        world.SensorEndTouch += (in SensorEndTouchEvent _) => endCount++;
+
+        BodyDef staticDef = new() { Type = BodyType.Static };
+        Body sensorBody = world.CreateBody(staticDef);
+
+        ShapeDef sensorShapeDef = new();
+        sensorShapeDef.IsSensor = true;
+        sensorShapeDef.EnableSensorEvents = true;
+        sensorBody.CreateShape(sensorShapeDef, new Circle { Radius = 1f });
+
+        BodyDef dynamicDef = new() { Type = BodyType.Dynamic, Position = new(-2f, 0f) };
+        Body dynamicBody = world.CreateBody(dynamicDef);
+
+        ShapeDef dynamicShapeDef = new() { Density = 1f };
+        dynamicShapeDef.EnableSensorEvents = true;
+        dynamicBody.CreateShape(dynamicShapeDef, new Circle { Radius = 0.5f });
+
+        dynamicBody.LinearVelocity = new Vector2(5f, 0f);
+        for (int i = 0; i < 60; ++i)
+        {
+            world.Step();
+        }
+
+        Assert.Equal(1, beginCount);
+        Assert.Equal(1, endCount);
+    }
+
+    [Fact]
+    public void ContactBeginEndHitEventsRaised()
+    {
+        int beginCount = 0;
+        int endCount = 0;
+        int hitCount = 0;
+
+        World world = World.CreateWorld(new WorldDef());
+        world.ContactBeginTouch += (in ContactBeginTouchEvent _) => beginCount++;
+        world.ContactEndTouch += (in ContactEndTouchEvent _) => endCount++;
+        world.ContactHit += (in ContactHitEvent _) => hitCount++;
+
+        BodyDef bodyDefA = new() { Type = BodyType.Dynamic, Position = new(-2f, 0f) };
+        BodyDef bodyDefB = new() { Type = BodyType.Dynamic, Position = new(2f, 0f) };
+        Body bodyA = world.CreateBody(bodyDefA);
+        Body bodyB = world.CreateBody(bodyDefB);
+
+        ShapeDef shapeDef = new() { Density = 1f };
+        shapeDef.EnableContactEvents = true;
+        shapeDef.EnableHitEvents = true;
+
+        Circle circle = new() { Radius = 0.5f };
+        bodyA.CreateShape(shapeDef, circle);
+        bodyB.CreateShape(shapeDef, circle);
+
+        bodyA.LinearVelocity = new Vector2(5f, 0f);
+        bodyB.LinearVelocity = new Vector2(-5f, 0f);
+        for (int i = 0; i < 120; ++i)
+        {
+            world.Step();
+        }
+
+        Assert.Equal(1, beginCount);
+        Assert.Equal(1, hitCount);
+        Assert.Equal(1, endCount);
+    }
+}

--- a/src/UnitTests/QueryTests.cs
+++ b/src/UnitTests/QueryTests.cs
@@ -1,0 +1,58 @@
+using Box2D;
+using System.Numerics;
+using Xunit;
+
+namespace UnitTests;
+
+public class QueryTests
+{
+    [Fact]
+    public void CastRayClosestHitsCircle()
+    {
+        World world = World.CreateWorld(new WorldDef());
+        BodyDef bodyDef = new() { Type = BodyType.Static, Position = new Vector2(5f, 0f) };
+        Body body = world.CreateBody(bodyDef);
+        body.CreateShape(new ShapeDef(), new Circle { Radius = 1f });
+
+        RayResult result = world.CastRayClosest(Vector2.Zero, new Vector2(10f, 0f), new QueryFilter());
+
+        Assert.True(result.Hit);
+        Assert.Equal(body.Shapes[0], result.Shape);
+    }
+
+    [Fact]
+    public void CastRayInvokesCallback()
+    {
+        World world = World.CreateWorld(new WorldDef());
+        BodyDef bodyDef = new() { Type = BodyType.Static, Position = new Vector2(2f, 0f) };
+        Body body = world.CreateBody(bodyDef);
+        body.CreateShape(new ShapeDef(), new Circle { Radius = 0.5f });
+
+        int callbackCount = 0;
+        world.CastRay(Vector2.Zero, new Vector2(5f, 0f), new QueryFilter(), (in RayResult _) =>
+        {
+            callbackCount++;
+            return true;
+        });
+
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public void OverlapAABBReturnsShape()
+    {
+        World world = World.CreateWorld(new WorldDef());
+        Body body = world.CreateBody(new BodyDef { Type = BodyType.Static });
+        body.CreateShape(new ShapeDef(), new Circle { Radius = 1f });
+
+        int count = 0;
+        AABB query = new(new Vector2(-2f, -2f), new Vector2(2f, 2f));
+        world.OverlapAABB(query, new QueryFilter(), (Shape _) =>
+        {
+            count++;
+            return true;
+        });
+
+        Assert.Equal(1, count);
+    }
+}

--- a/src/UnitTests/WorldTest.cs
+++ b/src/UnitTests/WorldTest.cs
@@ -31,7 +31,6 @@ namespace UnitTests
             };
             var body = world.CreateBody(bodyDef);
 
-            Assert.NotNull(body);
             Assert.True(body.Valid);
             Assert.Contains(body, world.Bodies);
         }
@@ -126,8 +125,6 @@ namespace UnitTests
                 Type = BodyType.Dynamic
             };
             var body = world.CreateBody(bodyDef);
-
-            Assert.NotNull(body);
 
             body.Destroy();
 


### PR DESCRIPTION
## Summary
- add event tests verifying begin/hit/end counts
- create QueryTests for ray cast and overlap APIs
- remove NotNull assertions on Body struct

## Testing
- `dotnet test --no-build -v minimal` *(fails: `dotnet` not found)*