### PR TITLE
Reduce build warnings

### DIFF
--- a/src/Box2DBindings/Defs/BodyDef.cs
+++ b/src/Box2DBindings/Defs/BodyDef.cs
@@ -16,6 +16,7 @@ public sealed class BodyDef
     internal BodyDefInternal _internal = new();
 
     //! \internal
+    /// <summary>Finalizes unmanaged resources.</summary>
     ~BodyDef()
     {
         if (_internal.Name != 0)

--- a/src/Box2DBindings/Hull.cs
+++ b/src/Box2DBindings/Hull.cs
@@ -8,7 +8,7 @@ namespace Box2D;
 /// A convex hull. Used to create convex polygons.
 /// </summary>
 /// <remarks>
-/// <b>Warning: Do not modify these values directly, instead use <see cref="Hull.Compute(System.Span{System.Numerics.Vector2})"/></b>
+/// <b>Warning: Do not modify these values directly, instead use <see cref="M:Box2D.Hull.Compute(System.ReadOnlySpan{Box2D.Vec2})"/></b>
 /// </remarks>
 [StructLayout(LayoutKind.Sequential)]
 [PublicAPI]

--- a/src/Box2DBindings/Shapes/ChainShape.cs
+++ b/src/Box2DBindings/Shapes/ChainShape.cs
@@ -148,17 +148,25 @@ public struct ChainShape : IEquatable<ChainShape>, IComparable<ChainShape>
     /// <returns>True if the chain shape is valid, false otherwise</returns>
     public bool Valid => b2Chain_IsValid(this) != 0;
 
+    /// <summary>Checks equality between two <see cref="ChainShape"/> values.</summary>
     public bool Equals(ChainShape other) =>
         index1 == other.index1 && world0 == other.world0 && generation == other.generation;
+
+    /// <inheritdoc/>
     public override bool Equals(object? obj) =>
         obj is ChainShape other && Equals(other);
+
+    /// <inheritdoc/>
     public override int GetHashCode() =>
         HashCode.Combine(index1, world0, generation);
-    
+
+    /// <summary>Default equality comparer for <see cref="ChainShape"/>.</summary>
     public static IEqualityComparer<ChainShape> DefaultEqualityComparer { get; } = ChainShapeComparer.Instance;
 
+    /// <summary>Default comparer for <see cref="ChainShape"/>.</summary>
     public static IComparer<ChainShape> DefaultComparer { get; } = ChainShapeComparer.Instance;
 
+    /// <summary>Compares this instance to another <see cref="ChainShape"/>.</summary>
     public int CompareTo(ChainShape other)
     {
         int index1Comparison = index1.CompareTo(other.index1);

--- a/src/Box2DBindings/Shapes/ShapeProxy.cs
+++ b/src/Box2DBindings/Shapes/ShapeProxy.cs
@@ -55,8 +55,6 @@ public unsafe struct ShapeProxy
             throw new ArgumentException($"Cannot set more than {MAX_POLYGON_VERTICES} points");
         if (points.Length < 1)
             throw new ArgumentOutOfRangeException(nameof(points), "Must have at least 1 point");
-        if (points == null)
-            throw new ArgumentNullException(nameof(points));
         
         Points = points;
         Radius = radius;

--- a/src/Box2DBindings/Stats.cs
+++ b/src/Box2DBindings/Stats.cs
@@ -3,6 +3,9 @@ using System.Runtime.InteropServices;
 
 namespace Box2D;
 
+/// <summary>
+/// Utility functions for collecting profiling and memory statistics from Box2D.
+/// </summary>
 [PublicAPI]
 public static class Stats
 {

--- a/src/Box2DBindings/World.cs
+++ b/src/Box2DBindings/World.cs
@@ -175,17 +175,17 @@ public sealed partial class World
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2World_Step")]
     private static extern void b2World_Step(WorldId worldId, float timeStep, int subStepCount);
     
-    private readonly TaskCallback bodyMoveTaskCallback; // root the task callback to avoid GC
+    private readonly TaskCallback bodyMoveTaskCallback = null!; // root the task callback to avoid GC
     private readonly nint bodyMoveTaskCallbackPointer;
-    private readonly TaskCallback sensorBeginTouchTaskCallback;
+    private readonly TaskCallback sensorBeginTouchTaskCallback = null!;
     private readonly nint sensorBeginTouchTaskCallbackPointer;
-    private readonly TaskCallback sensorEndTouchTaskCallback;
+    private readonly TaskCallback sensorEndTouchTaskCallback = null!;
     private readonly nint sensorEndTouchTaskCallbackPointer;
-    private readonly TaskCallback contactBeginTouchTaskCallback;
+    private readonly TaskCallback contactBeginTouchTaskCallback = null!;
     private readonly nint contactBeginTouchTaskCallbackPointer;
-    private readonly TaskCallback contactEndTouchTaskCallback;
+    private readonly TaskCallback contactEndTouchTaskCallback = null!;
     private readonly nint contactEndTouchTaskCallbackPointer;
-    private readonly TaskCallback contactHitTaskCallback;
+    private readonly TaskCallback contactHitTaskCallback = null!;
     private readonly nint contactHitTaskCallbackPointer;
 
     /// <summary>

--- a/src/UnitTests/WorldTest.cs
+++ b/src/UnitTests/WorldTest.cs
@@ -32,7 +32,6 @@ namespace UnitTests
             };
             var body = world.CreateBody(bodyDef);
 
-            Assert.NotNull(body);
             Assert.True(body.Valid);
             Assert.Contains(body, world.Bodies);
         }
@@ -127,8 +126,6 @@ namespace UnitTests
                 Type = BodyType.Dynamic
             };
             var body = world.CreateBody(bodyDef);
-
-            Assert.NotNull(body);
 
             body.Destroy();
 


### PR DESCRIPTION
## Summary
- document `Stats` class and BodyDef finalizer
- improve XML docs in `ChainShape`
- fix cref link in `Hull`
- drop redundant null check in `ShapeProxy`
- initialize callbacks in `World`
- clean up unit tests

## Testing
- `dotnet build Box2DDotnetBindings.sln --no-restore`
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `cp box2d-build/bin/libbox2d.so src/UnitTests/bin/Debug/net9.0`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults`