### PR TITLE
Clean build, zero warnings

### DIFF
--- a/src/Box2DBindings/Collision/Character Movement/CollisionPlane.cs
+++ b/src/Box2DBindings/Collision/Character Movement/CollisionPlane.cs
@@ -17,7 +17,7 @@ public struct CollisionPlane
     public Plane Plane;
 
     /// <summary>
-    /// Setting this to float.<see cref="System.Math.float.MaxValue"/> makes the plane as rigid as possible. Lower values can
+    /// Setting this to <see cref="float.MaxValue"/> makes the plane as rigid as possible. Lower values can
     /// make the plane collision soft. Usually in meters.
     /// </summary>
     public float PushLimit;
@@ -42,7 +42,7 @@ public struct CollisionPlane
     /// Constructs a new CollisionPlane object with the given parameters.
     /// </summary>
     /// <param name="plane">The collision plane between the mover and some shape.</param>
-    /// <param name="pushLimit">The plane rigidity. Setting this to float.<see cref="System.Math.float.MaxValue"/> makes the plane as rigid as possible. Lower values can make the plane collision soft. Usually in meters.</param>
+    /// <param name="pushLimit">The plane rigidity. Setting this to <see cref="float.MaxValue"/> makes the plane as rigid as possible. Lower values can make the plane collision soft. Usually in meters.</param>
     /// <param name="push">The push on the mover determined by b2SolvePlanes. Usually in meters.</param>
     /// <param name="clipVelocity">Indicates if <see cref="Mover.ClipVector(in Vec2,Box2D.Character_Movement.CollisionPlane[])"/> should clip against this plane. Should be false for soft collision.</param>
     public CollisionPlane(Plane plane, float pushLimit, float push, bool clipVelocity)

--- a/src/Box2DBindings/Comparers/WorldComparer.cs
+++ b/src/Box2DBindings/Comparers/WorldComparer.cs
@@ -25,7 +25,7 @@ sealed class WorldComparer : IEqualityComparer<World>, IComparer<World>
             return -1;
         if (y is null)
             return 1;
-        return x.id.Equals(y.id) ? 0 : x.id.GetHashCode() - y.id.GetHashCode();
+        return Comparer<int>.Default.Compare(x.id, y.id);
     }
 }
     

--- a/src/Box2DBindings/Comparers/WorldComparer.cs
+++ b/src/Box2DBindings/Comparers/WorldComparer.cs
@@ -5,12 +5,28 @@ namespace Box2D.Comparers;
 sealed class WorldComparer : IEqualityComparer<World>, IComparer<World>
 {
     public static readonly WorldComparer Instance = new();
-        
-    public bool Equals(World x, World y) => x.id.Equals(y.id);
+
+    public bool Equals(World? x, World? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null)
+            return false;
+        return x.id.Equals(y.id);
+    }
         
     public int GetHashCode(World obj) => obj.GetHashCode();
         
-    public int Compare(World x, World y) => x.id.Equals(y.id) ? 0 : x.id.GetHashCode() - y.id.GetHashCode();
+    public int Compare(World? x, World? y)
+    {
+        if (ReferenceEquals(x, y))
+            return 0;
+        if (x is null)
+            return -1;
+        if (y is null)
+            return 1;
+        return x.id.Equals(y.id) ? 0 : x.id.GetHashCode() - y.id.GetHashCode();
+    }
 }
     
 sealed class WorldIdComparer : IEqualityComparer<WorldId>, IComparer<WorldId>

--- a/src/Box2DBindings/World.cs
+++ b/src/Box2DBindings/World.cs
@@ -52,7 +52,7 @@ public sealed partial class World
     private static bool initialized;
 
     /// <summary>
-    /// Create a world for rigid body simulation. A world contains bodies, shapes, and constraints. You make create up to 128 worlds. Each world is completely independent and may be simulated in parallel.
+    /// Create a world for rigid body simulation. A world contains bodies, shapes, and constraints. You may create up to 128 worlds. Each world is completely independent and may be simulated in parallel.
     /// </summary>
     /// <param name="def">The world definition</param>
     /// <returns>The world</returns>
@@ -62,7 +62,7 @@ public sealed partial class World
     }
 
     /// <summary>
-    /// Create a world for rigid body simulation. A world contains bodies, shapes, and constraints. You make create up to 128 worlds. Each world is completely independent and may be simulated in parallel.
+    /// Create a world for rigid body simulation. A world contains bodies, shapes, and constraints. You may create up to 128 worlds. Each world is completely independent and may be simulated in parallel.
     /// </summary>
     /// <param name="def">The world definition</param>
     public World(WorldDef def)


### PR DESCRIPTION
## Summary
- fix bad `float.MaxValue` references
- ensure `WorldComparer` handles nulls
- tweak world creation docs

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `cp /workspace/native/libbox2d.so src/UnitTests/bin/Debug/net9.0/`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults`
