### PR TITLE
Fix doc comment typos

### DIFF
--- a/src/Box2DBindings/Gears.cs
+++ b/src/Box2DBindings/Gears.cs
@@ -4,7 +4,7 @@ using System;
 namespace Box2D;
 
 /// <summary>
-/// Gear calculation functionality no included in Box2D.
+/// Gear calculation functionality not included in Box2D.
 /// </summary>
 [PublicAPI]
 public class Gears
@@ -18,7 +18,7 @@ public class Gears
     /// <param name="teeth">The number of teeth that the gear should have.</param>
     /// <param name="toothLength">The length of the teeth - how far they stick out from the sprocket.</param>
     /// <returns>A list of shapes that were added to the Body.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">>If teeth is less than 3</exception>
+    /// <exception cref="ArgumentOutOfRangeException">If teeth is less than 3.</exception>
     public ReadOnlySpan<Shape> CreateInvoluteGear(
         Body body, ShapeDef shapeDef,
         float pitchRadius, int teeth, float toothLength)

--- a/src/Box2DBindings/Shapes/ShapeProxy.cs
+++ b/src/Box2DBindings/Shapes/ShapeProxy.cs
@@ -6,7 +6,7 @@ namespace Box2D;
 
 /// <summary>
 /// A distance proxy is used by the GJK algorithm. It encapsulates any shape.
-/// You can provide between 1 and <see cref="Constants.MAX_POLYGON_VERTICES" /> and a radius.
+/// You can provide between 1 and <see cref="Constants.MAX_POLYGON_VERTICES"/> points and a radius.
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
 [PublicAPI]


### PR DESCRIPTION
## Summary
- fix 'no included' comment in `Gears`
- clean up bad XML in `Gears`
- clarify `ShapeProxy` summary

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults`