### PR TITLE
Port missing externs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -271,6 +271,8 @@ jobs:
                     fi
                     cp "$lib" src/UnitTests/bin/Debug/net8.0/
                     cp "$lib" src/UnitTests/bin/Debug/net9.0/
+                    
+                    sync
 
             -   name: Run UnitTests (net8.0)
                 run: dotnet test src/UnitTests --configuration Debug --framework net8.0 --no-build --logger trx --results-directory TestResults

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -296,33 +296,33 @@ jobs:
             -   name: Deploy to GitHub Pages
                 uses: actions/deploy-pages@v4
     
-#    publish-bindings:
-#        name: Publish NuGet package
-#        needs: [ run-tests, build-box2d-main ]
-#        if: ${{ github.event_name != 'pull_request' &&
-#            !startsWith(github.ref_name, 'codex/') }}
-#        runs-on: [self-hosted, Linux, X64]
-#        steps:
-#            -   uses: actions/checkout@v4
+    publish-bindings:
+        name: Publish NuGet package
+        needs: [ run-tests, build-box2d-main ]
+        if: ${{ github.event_name != 'pull_request' &&
+            !startsWith(github.ref_name, 'codex/') }}
+        runs-on: [self-hosted, Linux, X64]
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: "Download native libs"
+                uses: actions/download-artifact@v4
+                with:
+                    path: src/Box2DBindings/native
+                    pattern: "*"
+
+            -   name: "Pack NuGet package"
+                run: |
+                    dotnet pack src/Box2DBindings \
+                      -p:Version=${{ needs.detect-tag.outputs.pkg_ver }} \
+                      -c Release
 #
-#            -   name: "Download native libs"
-#                uses: actions/download-artifact@v4
-#                with:
-#                    path: src/Box2DBindings/native
-#                    pattern: "*"
-#
-#            -   name: "Pack NuGet package"
-#                run: |
-#                    dotnet pack src/Box2DBindings \
-#                      -p:Version=${{ needs.detect-tag.outputs.pkg_ver }} \
-#                      -c Release
-##
-#            -   name: "Push to NuGet"
-#                if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'codex') }}
-#                env:
-#                    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-#                run: |
-#                  dotnet nuget push src/Box2DBindings/bin/Release/*.nupkg \
-#                    --api-key "$NUGET_API_KEY" \
-#                    --source "$NUGET_FEED"
+            -   name: "Push to NuGet"
+                if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'codex') }}
+                env:
+                    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+                run: |
+                  dotnet nuget push src/Box2DBindings/bin/Release/*.nupkg \
+                    --api-key "$NUGET_API_KEY" \
+                    --source "$NUGET_FEED"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -347,7 +347,11 @@ jobs:
                       exit 1
                     fi
                     cp "$lib" src/UnitTests/bin/Debug/net8.0/
+                    echo "-- net 8.0 --"
+                    ls src/UnitTests/bin/Debug/net8.0/
                     cp "$lib" src/UnitTests/bin/Debug/net9.0/
+                    echo "-- net 9.0 --"
+                    ls src/UnitTests/bin/Debug/net9.0/
 
             -   name: Run UnitTests (net8.0)
                 run: dotnet test src/UnitTests --configuration Debug --framework net8.0 --no-build --logger trx --results-directory TestResults
@@ -376,33 +380,33 @@ jobs:
             -   name: Deploy to GitHub Pages
                 uses: actions/deploy-pages@v4
     
-    publish-bindings:
-        name: Publish NuGet package
-        needs: [ run-tests, build-box2d-main ]
-        if: ${{ github.event_name != 'pull_request' &&
-            !startsWith(github.ref_name, 'codex/') }}
-        runs-on: [self-hosted, Linux, X64]
-        steps:
-            -   uses: actions/checkout@v4
-
-            -   name: "Download native libs"
-                uses: actions/download-artifact@v4
-                with:
-                    path: src/Box2DBindings/native
-                    pattern: "*"
-
-            -   name: "Pack NuGet package"
-                run: |
-                    dotnet pack src/Box2DBindings \
-                      -p:Version=${{ needs.detect-tag.outputs.pkg_ver }} \
-                      -c Release
+#    publish-bindings:
+#        name: Publish NuGet package
+#        needs: [ run-tests, build-box2d-main ]
+#        if: ${{ github.event_name != 'pull_request' &&
+#            !startsWith(github.ref_name, 'codex/') }}
+#        runs-on: [self-hosted, Linux, X64]
+#        steps:
+#            -   uses: actions/checkout@v4
 #
-            -   name: "Push to NuGet"
-                if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'codex') }}
-                env:
-                    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-                run: |
-                  dotnet nuget push src/Box2DBindings/bin/Release/*.nupkg \
-                    --api-key "$NUGET_API_KEY" \
-                    --source "$NUGET_FEED"
+#            -   name: "Download native libs"
+#                uses: actions/download-artifact@v4
+#                with:
+#                    path: src/Box2DBindings/native
+#                    pattern: "*"
+#
+#            -   name: "Pack NuGet package"
+#                run: |
+#                    dotnet pack src/Box2DBindings \
+#                      -p:Version=${{ needs.detect-tag.outputs.pkg_ver }} \
+#                      -c Release
+##
+#            -   name: "Push to NuGet"
+#                if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'codex') }}
+#                env:
+#                    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+#                run: |
+#                  dotnet nuget push src/Box2DBindings/bin/Release/*.nupkg \
+#                    --api-key "$NUGET_API_KEY" \
+#                    --source "$NUGET_FEED"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,11 +267,7 @@ jobs:
                       exit 1
                     fi
                     cp "$lib" src/UnitTests/bin/Debug/net8.0/
-                    echo "-- net 8.0 --"
-                    ls src/UnitTests/bin/Debug/net8.0/
                     cp "$lib" src/UnitTests/bin/Debug/net9.0/
-                    echo "-- net 9.0 --"
-                    ls src/UnitTests/bin/Debug/net9.0/
 
             -   name: Run UnitTests (net8.0)
                 run: dotnet test src/UnitTests --configuration Debug --framework net8.0 --no-build --logger trx --results-directory TestResults

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,46 +113,6 @@ jobs:
                       exit 1
                     fi
 
-            -   name: objdump for sanity
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [ -f box2d-build/bin/libbox2d.so ]; then
-                      objdump -f artefact/libbox2d.so
-                    fi
-                    if [ -f box2d-build/bin/libbox2d.dll ]; then
-                      objdump -f artefact/libbox2d.dll
-                    fi                   
-
-            -   name: Strip release artifacts if not 'linux-arm64' or "win-arm64"
-                if: ${{ matrix.target != 'linux-arm64' && matrix.target != 'win-arm64' }}
-                run: |
-                    if [[ -f artefact/libbox2d.so ]]; then
-                      strip artefact/libbox2d.so
-                    elif [[ -f artefact/libbox2d.dylib ]]; then
-                      strip -x artefact/libbox2d.dylib
-                    elif [[ -f artefact/libbox2d.dll ]]; then
-                      strip artefact/libbox2d.dll
-                    fi
-
-            -   name: UPX pack release artifacts if not 'win-arm64'
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [[ -f artefact/libbox2d.so ]]; then
-                      upx artefact/libbox2d.so
-                    elif [[ -f artefact/libbox2d.dll ]]; then
-                      upx artefact/libbox2d.dll
-                    fi
-
-            -   name: extra objdump for extra sanity
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [ -f box2d-build/bin/libbox2d.so ]; then
-                      objdump -f artefact/libbox2d.so
-                    fi
-                    if [ -f box2d-build/bin/libbox2d.dll ]; then
-                      objdump -f artefact/libbox2d.dll
-                    fi
-
             -   name: Upload artefacts
                 uses: actions/upload-artifact@v4
                 with:
@@ -265,46 +225,6 @@ jobs:
                       echo "Artefact directory is empty, aborting."
                       tree box2d-build/bin
                       exit 1
-                    fi
-
-            -   name: objdump for sanity
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [ -f box2d-build/bin/libbox2d.so ]; then
-                      objdump -f artefact/libbox2d.so
-                    fi
-                    if [ -f box2d-build/bin/libbox2d.dll ]; then
-                      objdump -f artefact/libbox2d.dll
-                    fi                   
-
-            -   name: Strip release artifacts if not 'linux-arm64' or "win-arm64"
-                if: ${{ matrix.target != 'linux-arm64' && matrix.target != 'win-arm64' }}
-                run: |
-                    if [[ -f artefact/libbox2d.so ]]; then
-                      strip artefact/libbox2d.so
-                    elif [[ -f artefact/libbox2d.dylib ]]; then
-                      strip -x artefact/libbox2d.dylib
-                    elif [[ -f artefact/libbox2d.dll ]]; then
-                      strip artefact/libbox2d.dll
-                    fi
-
-            -   name: UPX pack release artifacts if not 'win-arm64'
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [[ -f artefact/libbox2d.so ]]; then
-                      upx artefact/libbox2d.so
-                    elif [[ -f artefact/libbox2d.dll ]]; then
-                      upx artefact/libbox2d.dll
-                    fi
-
-            -   name: extra objdump for extra sanity
-                if: ${{ matrix.target != 'win-arm64' }}
-                run: |
-                    if [ -f box2d-build/bin/libbox2d.so ]; then
-                      objdump -f artefact/libbox2d.so
-                    fi
-                    if [ -f box2d-build/bin/libbox2d.dll ]; then
-                      objdump -f artefact/libbox2d.dll
                     fi
 
             -   name: Upload artefacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,7 +178,6 @@ jobs:
 
         steps:
             -   id: purge
-                name: Move previous run to /dev/null for safekeeping 
                 run: |
                     rm -rf ./* 
             
@@ -244,6 +243,10 @@ jobs:
             id-token: write
             pages: write
         steps:
+            -   id: purge
+                run: |
+                    rm -rf ./* 
+            
             -   uses: actions/checkout@v4
 
             -   name: "Download native libs"
@@ -281,6 +284,10 @@ jobs:
         if: github.ref == 'refs/heads/main'
         runs-on: [self-hosted, Linux, X64]
         steps:
+            -   id: purge
+                run: |
+                    rm -rf ./* 
+
             -   uses: actions/checkout@v4
 
             -   name: Generate Doxygen Documentation
@@ -303,6 +310,10 @@ jobs:
             !startsWith(github.ref_name, 'codex/') }}
         runs-on: [self-hosted, Linux, X64]
         steps:
+            -   id: purge
+                run: |
+                    rm -rf ./*
+                    
             -   uses: actions/checkout@v4
 
             -   name: "Download native libs"

--- a/src/Box2DBindings/Core_Externs.cs
+++ b/src/Box2DBindings/Core_Externs.cs
@@ -64,12 +64,6 @@ namespace Box2D
 
         static unsafe Core()
         {
-#if DEBUG
-            if (!File.Exists(libraryName))
-            {
-                throw new FileNotFoundException($"The library {libraryName} was not found in current directory: {Environment.CurrentDirectory}");
-            }
-#endif
             var lib = NativeLibrary.Load(libraryName);
 
             NativeLibrary.TryGetExport(lib, "b2GetVersion", out var p0);

--- a/src/Box2DBindings/Core_Externs.cs
+++ b/src/Box2DBindings/Core_Externs.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Box2D
@@ -62,6 +64,12 @@ namespace Box2D
 
         static unsafe Core()
         {
+#if DEBUG
+            if (!File.Exists(libraryName))
+            {
+                throw new FileNotFoundException($"The library {libraryName} was not found in current directory: {Environment.CurrentDirectory}");
+            }
+#endif
             var lib = NativeLibrary.Load(libraryName);
 
             NativeLibrary.TryGetExport(lib, "b2GetVersion", out var p0);

--- a/src/Box2DBindings/Joints/PrismaticJoint.cs
+++ b/src/Box2DBindings/Joints/PrismaticJoint.cs
@@ -44,16 +44,11 @@ public sealed partial class PrismaticJoint : Joint
         set => b2PrismaticJoint_SetSpringDampingRatio(id, value);
     }
     
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_SetTargetTranslation")]
-    private static extern void b2PrismaticJoint_SetTargetTranslation(JointId jointId, float translation);
-    
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_GetTargetTranslation")]
-    private static extern float b2PrismaticJoint_GetTargetTranslation(JointId jointId);
     
     /// <summary>
     /// The prismatic joint spring target translation
     /// </summary>
-    public float TargetTranslation
+    public unsafe float TargetTranslation
     {
         get => b2PrismaticJoint_GetTargetTranslation(id);
         set => b2PrismaticJoint_SetTargetTranslation(id, value);

--- a/src/Box2DBindings/Joints/PrismaticJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/PrismaticJoint_Externs.cs
@@ -25,6 +25,8 @@ namespace Box2D
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2PrismaticJoint_GetMotorForce;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2PrismaticJoint_GetTranslation;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2PrismaticJoint_GetSpeed;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float, void> b2PrismaticJoint_SetTargetTranslation;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2PrismaticJoint_GetTargetTranslation;
 
     static unsafe PrismaticJoint()
     {
@@ -49,6 +51,8 @@ namespace Box2D
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_GetMotorForce", out var p17);
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_GetTranslation", out var p18);
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_GetSpeed", out var p19);
+        NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_SetTargetTranslation", out var p20);
+        NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_GetTargetTranslation", out var p21);
 
         b2PrismaticJoint_EnableSpring = (delegate* unmanaged[Cdecl]<JointId, byte, void>)p0;
         b2PrismaticJoint_IsSpringEnabled = (delegate* unmanaged[Cdecl]<JointId, byte>)p1;
@@ -70,6 +74,8 @@ namespace Box2D
         b2PrismaticJoint_GetMotorForce = (delegate* unmanaged[Cdecl]<JointId, float>)p17;
         b2PrismaticJoint_GetTranslation = (delegate* unmanaged[Cdecl]<JointId, float>)p18;
         b2PrismaticJoint_GetSpeed = (delegate* unmanaged[Cdecl]<JointId, float>)p19;
+        b2PrismaticJoint_SetTargetTranslation = (delegate* unmanaged[Cdecl]<JointId, float, void>)p20;
+        b2PrismaticJoint_GetTargetTranslation = (delegate* unmanaged[Cdecl]<JointId, float>)p21;
     }
 #else
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_EnableSpring")]
@@ -131,6 +137,12 @@ namespace Box2D
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_GetSpeed")]
     private static extern float b2PrismaticJoint_GetSpeed(JointId jointId);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_SetTargetTranslation")]
+    private static extern void b2PrismaticJoint_SetTargetTranslation(JointId jointId, float translation);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2PrismaticJoint_GetTargetTranslation")]
+    private static extern float b2PrismaticJoint_GetTargetTranslation(JointId jointId);
 #endif
     }
 }

--- a/src/Box2DBindings/Joints/RevoluteJoint.cs
+++ b/src/Box2DBindings/Joints/RevoluteJoint.cs
@@ -48,16 +48,11 @@ public sealed partial class RevoluteJoint : Joint
         set => b2RevoluteJoint_SetSpringDampingRatio(id, value);
     }
     
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_SetTargetAngle")]
-    private static extern void b2RevoluteJoint_SetTargetAngle(JointId jointId, float angle);
-    
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_GetTargetAngle")]
-    private static extern float b2RevoluteJoint_GetTargetAngle(JointId jointId);
     
     /// <summary>
     /// The revolute joint spring target angle in radians
     /// </summary>
-    public float TargetAngle
+    public unsafe float TargetAngle
     {
         get => b2RevoluteJoint_GetTargetAngle(id);
         set => b2RevoluteJoint_SetTargetAngle(id, value);

--- a/src/Box2DBindings/Joints/RevoluteJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/RevoluteJoint_Externs.cs
@@ -24,6 +24,8 @@ namespace Box2D
         private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2RevoluteJoint_GetMotorTorque;
         private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float, void> b2RevoluteJoint_SetMaxMotorTorque;
         private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2RevoluteJoint_GetMaxMotorTorque;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float, void> b2RevoluteJoint_SetTargetAngle;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, float> b2RevoluteJoint_GetTargetAngle;
 
         static unsafe RevoluteJoint()
         {
@@ -47,6 +49,8 @@ namespace Box2D
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_GetMotorTorque", out var p16);
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_SetMaxMotorTorque", out var p17);
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_GetMaxMotorTorque", out var p18);
+            NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_SetTargetAngle", out var p19);
+            NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_GetTargetAngle", out var p20);
 
             b2RevoluteJoint_EnableSpring = (delegate* unmanaged[Cdecl]<JointId, byte, void>)p0;
             b2RevoluteJoint_IsSpringEnabled = (delegate* unmanaged[Cdecl]<JointId, byte>)p1;
@@ -67,6 +71,8 @@ namespace Box2D
             b2RevoluteJoint_GetMotorTorque = (delegate* unmanaged[Cdecl]<JointId, float>)p16;
             b2RevoluteJoint_SetMaxMotorTorque = (delegate* unmanaged[Cdecl]<JointId, float, void>)p17;
             b2RevoluteJoint_GetMaxMotorTorque = (delegate* unmanaged[Cdecl]<JointId, float>)p18;
+            b2RevoluteJoint_SetTargetAngle = (delegate* unmanaged[Cdecl]<JointId, float, void>)p19;
+            b2RevoluteJoint_GetTargetAngle = (delegate* unmanaged[Cdecl]<JointId, float>)p20;
         }
 #else
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_EnableSpring")]
@@ -125,6 +131,12 @@ namespace Box2D
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_GetMaxMotorTorque")]
     private static extern float b2RevoluteJoint_GetMaxMotorTorque(JointId jointId);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_SetTargetAngle")]
+    private static extern void b2RevoluteJoint_SetTargetAngle(JointId jointId, float angle);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2RevoluteJoint_GetTargetAngle")]
+    private static extern float b2RevoluteJoint_GetTargetAngle(JointId jointId);
 #endif
     }
 }

--- a/src/Box2DBindings/Shapes/Shape.cs
+++ b/src/Box2DBindings/Shapes/Shape.cs
@@ -247,16 +247,11 @@ public partial struct Shape : IEquatable<Shape>, IComparable<Shape>
         }
     }
 
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_SetSurfaceMaterial")]
-    private static extern void b2Shape_SetSurfaceMaterial(Shape shape, SurfaceMaterial surfaceMaterial);
-    
-    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_GetSurfaceMaterial")]
-    private static extern SurfaceMaterial b2Shape_GetSurfaceMaterial(Shape shape);
     
     /// <summary>
     /// Gets/sets the surface material for this shape
     /// </summary>
-    public SurfaceMaterial SurfaceMaterial
+    public unsafe SurfaceMaterial SurfaceMaterial
     {
         get => Valid ? b2Shape_GetSurfaceMaterial(this) : throw new InvalidOperationException("Shape is not valid");
         set

--- a/src/Box2DBindings/Shapes/Shape_Externs.cs
+++ b/src/Box2DBindings/Shapes/Shape_Externs.cs
@@ -24,6 +24,8 @@ namespace Box2D
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, float> b2Shape_GetRestitution;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, int, void> b2Shape_SetMaterial;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, int> b2Shape_GetMaterial;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, SurfaceMaterial, void> b2Shape_SetSurfaceMaterial;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, SurfaceMaterial> b2Shape_GetSurfaceMaterial;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, Filter> b2Shape_GetFilter;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, Filter, void> b2Shape_SetFilter;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, byte, void> b2Shape_EnableContactEvents;
@@ -100,6 +102,8 @@ namespace Box2D
             NativeLibrary.TryGetExport(lib, "b2Shape_GetAABB", out var p42);
             NativeLibrary.TryGetExport(lib, "b2Shape_GetMassData", out var p43);
             NativeLibrary.TryGetExport(lib, "b2Shape_GetClosestPoint", out var p44);
+            NativeLibrary.TryGetExport(lib, "b2Shape_SetSurfaceMaterial", out var p45);
+            NativeLibrary.TryGetExport(lib, "b2Shape_GetSurfaceMaterial", out var p46);
 
             b2DestroyShape = (delegate* unmanaged[Cdecl]<Shape, byte, void>)p0;
             b2Shape_IsValid = (delegate* unmanaged[Cdecl]<Shape, byte>)p1;
@@ -146,6 +150,8 @@ namespace Box2D
             b2Shape_GetAABB = (delegate* unmanaged[Cdecl]<Shape, AABB>)p42;
             b2Shape_GetMassData = (delegate* unmanaged[Cdecl]<Shape, MassData>)p43;
             b2Shape_GetClosestPoint = (delegate* unmanaged[Cdecl]<Shape, Vec2, Vec2>)p44;
+            b2Shape_SetSurfaceMaterial = (delegate* unmanaged[Cdecl]<Shape, SurfaceMaterial, void>)p45;
+            b2Shape_GetSurfaceMaterial = (delegate* unmanaged[Cdecl]<Shape, SurfaceMaterial>)p46;
         }
         #else
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2DestroyShape")]
@@ -282,6 +288,12 @@ namespace Box2D
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_GetClosestPoint")]
     private static extern Vec2 b2Shape_GetClosestPoint(Shape shape, Vec2 target);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_SetSurfaceMaterial")]
+    private static extern void b2Shape_SetSurfaceMaterial(Shape shape, SurfaceMaterial surfaceMaterial);
+
+    [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_GetSurfaceMaterial")]
+    private static extern SurfaceMaterial b2Shape_GetSurfaceMaterial(Shape shape);
 #endif
     }
 }


### PR DESCRIPTION
## Summary
- move shape surface material externs into externs file
- do the same for prismatic and revolute joints

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults` *(fails: Failed: 32, Passed: 4)*