### PR TITLE
Centralize native lib load, buffer pooling

### DIFF
--- a/src/Box2DBindings/Body_Externs.cs
+++ b/src/Box2DBindings/Body_Externs.cs
@@ -78,7 +78,7 @@ namespace Box2D
 
         static unsafe Body()
         {
-            nint lib = NativeLibrary.Load(libraryName);
+            nint lib = Core.NativeLibHandle;
             NativeLibrary.TryGetExport(lib, "b2DestroyBody", out var p0);
             NativeLibrary.TryGetExport(lib, "b2Body_IsValid", out var p1);
             NativeLibrary.TryGetExport(lib, "b2Body_GetType", out var p2);

--- a/src/Box2DBindings/Collision/Character Movement/Mover_Externs.cs
+++ b/src/Box2DBindings/Collision/Character Movement/Mover_Externs.cs
@@ -10,7 +10,7 @@ static partial class Mover
         
     static unsafe Mover()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
 
         NativeLibrary.TryGetExport(lib, "b2SolvePlanes", out var solvePtr);
         NativeLibrary.TryGetExport(lib, "b2ClipVector", out var clipPtr);

--- a/src/Box2DBindings/Collision/Character Movement/Plane_Externs.cs
+++ b/src/Box2DBindings/Collision/Character Movement/Plane_Externs.cs
@@ -10,7 +10,7 @@ partial struct Plane
 
     static unsafe Plane()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2IsValidPlane", out var ptr);
 
         if (ptr == IntPtr.Zero)

--- a/src/Box2DBindings/Collision/Collision.cs
+++ b/src/Box2DBindings/Collision/Collision.cs
@@ -85,7 +85,7 @@ public static class Collision
 
     static unsafe Collision()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
 
         NativeLibrary.TryGetExport(lib, "b2CollideCircles", out var p0);
         NativeLibrary.TryGetExport(lib, "b2CollideCapsuleAndCircle", out var p1);

--- a/src/Box2DBindings/Collision/DynamicTree.cs
+++ b/src/Box2DBindings/Collision/DynamicTree.cs
@@ -1,6 +1,7 @@
 using JetBrains.Annotations;
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 
 namespace Box2D;
 
@@ -53,6 +54,7 @@ public unsafe partial struct DynamicTree
     /// Destroy the tree, freeing the node pool.
     /// </summary>
     /// <remarks>This wraps <a href="https://box2d.org/documentation/group__collision.html#https://box2d.org/documentation/group__tree.html#ga3ffc351d31681acfb3b342eaf1ad1841">b2DynamicTree_Destroy</a></remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Destroy() => b2DynamicTree_Destroy(ref this);
     
     /// <summary>

--- a/src/Box2DBindings/Collision/DynamicTree_Externs.cs
+++ b/src/Box2DBindings/Collision/DynamicTree_Externs.cs
@@ -34,7 +34,7 @@ unsafe partial struct DynamicTree
 
     static DynamicTree()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DynamicTree_Create", out var p0);
         NativeLibrary.TryGetExport(lib, "b2DynamicTree_Destroy", out var p1);
         NativeLibrary.TryGetExport(lib, "b2DynamicTree_CreateProxy", out var p2);

--- a/src/Box2DBindings/Comparers/BodyComparer.cs
+++ b/src/Box2DBindings/Comparers/BodyComparer.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Box2D.Comparers;
 
@@ -8,9 +9,12 @@ sealed class BodyComparer : IEqualityComparer<Body>, IComparer<Body>
 {
     public static readonly BodyComparer Instance = new();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(Body x, Body y) => x.Equals(y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetHashCode(Body obj) => obj.GetHashCode();
-        
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Compare(Body x, Body y) => x.Equals(y) ? 0 : Comparer<Body>.Default.Compare(x, y);
 }

--- a/src/Box2DBindings/Comparers/ChainShapeComparer.cs
+++ b/src/Box2DBindings/Comparers/ChainShapeComparer.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Box2D.Comparers
 {
@@ -8,10 +9,13 @@ namespace Box2D.Comparers
     {
         public static readonly ChainShapeComparer Instance = new();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(ChainShape x, ChainShape y) => x.Equals(y);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetHashCode(ChainShape obj) => obj.GetHashCode();
-        
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(ChainShape x, ChainShape y) => x.Equals(y) ? 0 : Comparer<ChainShape>.Default.Compare(x, y);
     }
 }

--- a/src/Box2DBindings/Comparers/ShapeComparer.cs
+++ b/src/Box2DBindings/Comparers/ShapeComparer.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Box2D.Comparers;
 
@@ -8,9 +9,12 @@ sealed class ShapeComparer : IEqualityComparer<Shape>, IComparer<Shape>
 {
     public static readonly ShapeComparer Instance = new();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(Shape x, Shape y) => x.Equals(y);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetHashCode(Shape obj) => obj.GetHashCode();
-        
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Compare(Shape x, Shape y) => x.Equals(y) ? 0 : Comparer<Shape>.Default.Compare(x, y);
 }

--- a/src/Box2DBindings/Comparers/WorldComparer.cs
+++ b/src/Box2DBindings/Comparers/WorldComparer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Box2D.Comparers;
 
@@ -6,6 +7,7 @@ sealed class WorldComparer : IEqualityComparer<World>, IComparer<World>
 {
     public static readonly WorldComparer Instance = new();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(World? x, World? y)
     {
         if (ReferenceEquals(x, y))
@@ -15,8 +17,10 @@ sealed class WorldComparer : IEqualityComparer<World>, IComparer<World>
         return EqualityComparer<WorldId>.Default.Equals(x.id, y.id);
     }
         
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetHashCode(World obj) => obj.id.GetHashCode();
         
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Compare(World? x, World? y)
     {
         if (ReferenceEquals(x, y))
@@ -33,10 +37,13 @@ sealed class WorldIdComparer : IEqualityComparer<WorldId>, IComparer<WorldId>
 {
     public static readonly WorldIdComparer Instance = new();
         
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Equals(WorldId x, WorldId y) => x.Equals(y);
         
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int GetHashCode(WorldId obj) => obj.GetHashCode();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Compare(WorldId x, WorldId y)
     {
         if (x.Equals(y))

--- a/src/Box2DBindings/ConcurrentHashSet.cs
+++ b/src/Box2DBindings/ConcurrentHashSet.cs
@@ -15,7 +15,7 @@ sealed class ConcurrentHashSet<T> : IEnumerable<T> where T : notnull
         _locks = new object[StripeCount];
         for (int i = 0; i < StripeCount; i++)
         {
-            _sets[i] = new HashSet<T>();
+            _sets[i] = new HashSet<T>(1536);
             _locks[i] = new object();
         }
     }

--- a/src/Box2DBindings/Core.cs
+++ b/src/Box2DBindings/Core.cs
@@ -22,6 +22,7 @@ public static partial class Core
             PlatformID.MacOSX => "dylib",
             _ => ""
         };
+    internal static readonly nint NativeLibHandle;
     #else
     internal const string libraryName = "libbox2d";
     #endif

--- a/src/Box2DBindings/Core_Externs.cs
+++ b/src/Box2DBindings/Core_Externs.cs
@@ -75,7 +75,8 @@ namespace Box2D
             }
 #endif
 
-            var lib = NativeLibrary.Load(libraryName);
+            Core.NativeLibHandle = NativeLibrary.Load(libraryName);
+            var lib = Core.NativeLibHandle;
 
             NativeLibrary.TryGetExport(lib, "b2GetVersion", out var p0);
             NativeLibrary.TryGetExport(lib, "b2GetTicks", out var p1);

--- a/src/Box2DBindings/DebugDraw/DebugDrawInternal.cs
+++ b/src/Box2DBindings/DebugDraw/DebugDrawInternal.cs
@@ -15,7 +15,7 @@ struct DebugDrawInternal
 
     static unsafe DebugDrawInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultDebugDraw", out var ptr);
         b2DefaultDebugDraw = (delegate* unmanaged[Cdecl]<DebugDrawInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/ExplosionDef.cs
+++ b/src/Box2DBindings/Defs/ExplosionDef.cs
@@ -16,7 +16,7 @@ public struct ExplosionDef
 
     static unsafe ExplosionDef()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultExplosionDef", out var ptr);
         b2DefaultExplosionDef = (delegate* unmanaged[Cdecl]<ExplosionDef>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/BodyDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/BodyDefInternal.cs
@@ -11,7 +11,7 @@ struct BodyDefInternal
 
     static unsafe BodyDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultBodyDef", out var ptr);
         b2DefaultBodyDef = (delegate* unmanaged[Cdecl]<BodyDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/ChainDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/ChainDefInternal.cs
@@ -11,7 +11,7 @@ unsafe struct ChainDefInternal
 
     static ChainDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultChainDef", out var ptr);
         b2DefaultChainDef = (delegate* unmanaged[Cdecl]<ChainDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/DistanceJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/DistanceJointDefInternal.cs
@@ -11,7 +11,7 @@ struct DistanceJointDefInternal
 
     static unsafe DistanceJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultDistanceJointDef", out var ptr);
         b2DefaultDistanceJointDef = (delegate* unmanaged[Cdecl]<DistanceJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/FilterJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/FilterJointDefInternal.cs
@@ -11,7 +11,7 @@ struct FilterJointDefInternal
 
     static unsafe FilterJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultNullJointDef", out var ptr);
         b2DefaultNullJointDef = (delegate* unmanaged[Cdecl]<FilterJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/MotorJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/MotorJointDefInternal.cs
@@ -11,7 +11,7 @@ struct MotorJointDefInternal
 
     static unsafe MotorJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultMotorJointDef", out var ptr);
         b2DefaultMotorJointDef = (delegate* unmanaged[Cdecl]<MotorJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/MouseJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/MouseJointDefInternal.cs
@@ -11,7 +11,7 @@ struct MouseJointDefInternal
 
     static unsafe MouseJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultMouseJointDef", out var ptr);
         b2DefaultMouseJointDef = (delegate* unmanaged[Cdecl]<MouseJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/PrismaticJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/PrismaticJointDefInternal.cs
@@ -11,7 +11,7 @@ struct PrismaticJointDefInternal
 
     static unsafe PrismaticJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultPrismaticJointDef", out var ptr);
         b2DefaultPrismaticJointDef = (delegate* unmanaged[Cdecl]<PrismaticJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/RevoluteJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/RevoluteJointDefInternal.cs
@@ -11,7 +11,7 @@ struct RevoluteJointDefInternal
 
     static unsafe RevoluteJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultRevoluteJointDef", out var ptr);
         b2DefaultRevoluteJointDef = (delegate* unmanaged[Cdecl]<RevoluteJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/ShapeDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/ShapeDefInternal.cs
@@ -11,7 +11,7 @@ struct ShapeDefInternal
 
     static unsafe ShapeDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultShapeDef", out var ptr);
         b2DefaultShapeDef = (delegate* unmanaged[Cdecl]<ShapeDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/WeldJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/WeldJointDefInternal.cs
@@ -11,7 +11,7 @@ struct WeldJointDefInternal
 
     static unsafe WeldJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultWeldJointDef", out var ptr);
         b2DefaultWeldJointDef = (delegate* unmanaged[Cdecl]<WeldJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/WheelJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/WheelJointDefInternal.cs
@@ -11,7 +11,7 @@ struct WheelJointDefInternal
 
     static unsafe WheelJointDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultWheelJointDef", out var ptr);
         b2DefaultWheelJointDef = (delegate* unmanaged[Cdecl]<WheelJointDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Defs/InternalDefs/WorldDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/WorldDefInternal.cs
@@ -11,7 +11,7 @@ struct WorldDefInternal
 
     static unsafe WorldDefInternal()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultWorldDef", out var ptr);
         b2DefaultWorldDef = (delegate* unmanaged[Cdecl]<WorldDefInternal>)ptr;
     }

--- a/src/Box2DBindings/Filter.cs
+++ b/src/Box2DBindings/Filter.cs
@@ -14,7 +14,7 @@ public struct Filter
 
     static unsafe Filter()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultFilter", out var ptr);
         b2DefaultFilter = (delegate* unmanaged[Cdecl]<Filter>)ptr;
     }

--- a/src/Box2DBindings/Hull.cs
+++ b/src/Box2DBindings/Hull.cs
@@ -20,7 +20,7 @@ public ref struct Hull
 
     static unsafe Hull()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2ComputeHull", out var ptr1);
         NativeLibrary.TryGetExport(lib, "b2ValidateHull", out var ptr2);
         b2ComputeHull = (delegate* unmanaged[Cdecl]<Vec2*, int, Hull>)ptr1;

--- a/src/Box2DBindings/Joints/DistanceJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/DistanceJoint_Externs.cs
@@ -29,7 +29,7 @@ partial class DistanceJoint
 
     static unsafe DistanceJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DistanceJoint_SetLength", out var p0);
         NativeLibrary.TryGetExport(lib, "b2DistanceJoint_GetLength", out var p1);
         NativeLibrary.TryGetExport(lib, "b2DistanceJoint_EnableSpring", out var p2);

--- a/src/Box2DBindings/Joints/Joint.cs
+++ b/src/Box2DBindings/Joints/Joint.cs
@@ -1,5 +1,6 @@
 using JetBrains.Annotations;
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Box2D;
@@ -47,6 +48,7 @@ public partial class Joint
     /// <summary>
     /// Destroys this joint
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void Destroy()
     {
         if (!Valid) return;

--- a/src/Box2DBindings/Joints/Joint_Externs.cs
+++ b/src/Box2DBindings/Joints/Joint_Externs.cs
@@ -23,7 +23,7 @@ namespace Box2D
 
     static unsafe Joint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DestroyJoint", out var p0);
         NativeLibrary.TryGetExport(lib, "b2Joint_IsValid", out var p1);
         NativeLibrary.TryGetExport(lib, "b2Joint_GetType", out var p2);

--- a/src/Box2DBindings/Joints/MotorJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/MotorJoint_Externs.cs
@@ -18,7 +18,7 @@ namespace Box2D
 
     static unsafe MotorJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2MotorJoint_SetLinearOffset", out var p0);
         NativeLibrary.TryGetExport(lib, "b2MotorJoint_GetLinearOffset", out var p1);
         NativeLibrary.TryGetExport(lib, "b2MotorJoint_SetAngularOffset", out var p2);

--- a/src/Box2DBindings/Joints/MouseJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/MouseJoint_Externs.cs
@@ -16,7 +16,7 @@ namespace Box2D
 
     static unsafe MouseJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2MouseJoint_SetTarget", out var p0);
         NativeLibrary.TryGetExport(lib, "b2MouseJoint_GetTarget", out var p1);
         NativeLibrary.TryGetExport(lib, "b2MouseJoint_SetSpringHertz", out var p2);

--- a/src/Box2DBindings/Joints/PrismaticJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/PrismaticJoint_Externs.cs
@@ -30,7 +30,7 @@ namespace Box2D
 
     static unsafe PrismaticJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_EnableSpring", out var p0);
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_IsSpringEnabled", out var p1);
         NativeLibrary.TryGetExport(lib, "b2PrismaticJoint_SetSpringHertz", out var p2);

--- a/src/Box2DBindings/Joints/RevoluteJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/RevoluteJoint_Externs.cs
@@ -29,7 +29,7 @@ namespace Box2D
 
         static unsafe RevoluteJoint()
         {
-            nint lib = NativeLibrary.Load(libraryName);
+            nint lib = Core.NativeLibHandle;
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_EnableSpring", out var p0);
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_IsSpringEnabled", out var p1);
             NativeLibrary.TryGetExport(lib, "b2RevoluteJoint_SetSpringHertz", out var p2);

--- a/src/Box2DBindings/Joints/WeldJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/WeldJoint_Externs.cs
@@ -18,7 +18,7 @@ namespace Box2D
 
     static unsafe WeldJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2WeldJoint_GetReferenceAngle", out var p0);
         NativeLibrary.TryGetExport(lib, "b2WeldJoint_SetReferenceAngle", out var p1);
         NativeLibrary.TryGetExport(lib, "b2WeldJoint_SetLinearHertz", out var p2);

--- a/src/Box2DBindings/Joints/WheelJoint_Externs.cs
+++ b/src/Box2DBindings/Joints/WheelJoint_Externs.cs
@@ -26,7 +26,7 @@ namespace Box2D
 
     static unsafe WheelJoint()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2WheelJoint_EnableSpring", out var p0);
         NativeLibrary.TryGetExport(lib, "b2WheelJoint_IsSpringEnabled", out var p1);
         NativeLibrary.TryGetExport(lib, "b2WheelJoint_SetSpringHertz", out var p2);

--- a/src/Box2DBindings/QueryFilter.cs
+++ b/src/Box2DBindings/QueryFilter.cs
@@ -17,7 +17,7 @@ public ref struct QueryFilter
 
     static unsafe QueryFilter()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultQueryFilter", out var ptr);
         b2DefaultQueryFilter = (delegate* unmanaged[Cdecl]<QueryFilter>)ptr;
     }

--- a/src/Box2DBindings/RayCasting/RayCastInput.cs
+++ b/src/Box2DBindings/RayCasting/RayCastInput.cs
@@ -15,7 +15,7 @@ public struct RayCastInput
 
     static unsafe RayCastInput()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2IsValidRay", out var ptr);
         b2IsValidRay = (delegate* unmanaged[Cdecl]<in RayCastInput, byte>)ptr;
     }

--- a/src/Box2DBindings/Shapes/Capsule_Externs.cs
+++ b/src/Box2DBindings/Shapes/Capsule_Externs.cs
@@ -13,7 +13,7 @@ namespace Box2D
 
     static unsafe Capsule()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2ComputeCapsuleMass", out var p0);
         NativeLibrary.TryGetExport(lib, "b2ComputeCapsuleAABB", out var p1);
         NativeLibrary.TryGetExport(lib, "b2PointInCapsule", out var p2);

--- a/src/Box2DBindings/Shapes/ChainShape.cs
+++ b/src/Box2DBindings/Shapes/ChainShape.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Box2D;
@@ -32,6 +33,7 @@ public partial struct ChainShape : IEquatable<ChainShape>, IComparable<ChainShap
     /// Destroys this chain shape
     /// </summary>
     /// <remarks>This will remove the chain shape from the world and destroy all contacts associated with this shape</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void Destroy()
     {
         if (!Valid) return;

--- a/src/Box2DBindings/Shapes/ChainShape_Externs.cs
+++ b/src/Box2DBindings/Shapes/ChainShape_Externs.cs
@@ -19,7 +19,7 @@ namespace Box2D
 
     static unsafe ChainShape()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DestroyChain", out var p0);
         NativeLibrary.TryGetExport(lib, "b2Chain_GetWorld", out var p1);
         NativeLibrary.TryGetExport(lib, "b2Chain_GetSegmentCount", out var p2);

--- a/src/Box2DBindings/Shapes/Circle_Externs.cs
+++ b/src/Box2DBindings/Shapes/Circle_Externs.cs
@@ -13,7 +13,7 @@ namespace Box2D
 
     static unsafe Circle()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2ComputeCircleMass", out var p0);
         NativeLibrary.TryGetExport(lib, "b2ComputeCircleAABB", out var p1);
         NativeLibrary.TryGetExport(lib, "b2PointInCircle", out var p2);

--- a/src/Box2DBindings/Shapes/Polygon_Externs.cs
+++ b/src/Box2DBindings/Shapes/Polygon_Externs.cs
@@ -22,7 +22,7 @@ namespace Box2D
 
         static unsafe Polygon()
         {
-            nint lib = NativeLibrary.Load(libraryName);
+            nint lib = Core.NativeLibHandle;
             NativeLibrary.TryGetExport(lib, "b2MakePolygon", out var p0);
             NativeLibrary.TryGetExport(lib, "b2MakeOffsetPolygon", out var p1);
             NativeLibrary.TryGetExport(lib, "b2MakeOffsetRoundedPolygon", out var p2);

--- a/src/Box2DBindings/Shapes/Segment_Externs.cs
+++ b/src/Box2DBindings/Shapes/Segment_Externs.cs
@@ -12,7 +12,7 @@ namespace Box2D
 
     static unsafe Segment()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2ComputeSegmentAABB", out var p0);
         NativeLibrary.TryGetExport(lib, "b2RayCastSegment", out var p1);
         NativeLibrary.TryGetExport(lib, "b2ShapeCastSegment", out var p2);

--- a/src/Box2DBindings/Shapes/Shape_Externs.cs
+++ b/src/Box2DBindings/Shapes/Shape_Externs.cs
@@ -56,7 +56,7 @@ namespace Box2D
 
         static unsafe Shape()
         {
-            nint lib = NativeLibrary.Load(libraryName);
+            nint lib = Core.NativeLibHandle;
             NativeLibrary.TryGetExport(lib, "b2DestroyShape", out var p0);
             NativeLibrary.TryGetExport(lib, "b2Shape_IsValid", out var p1);
             NativeLibrary.TryGetExport(lib, "b2Shape_GetType", out var p2);

--- a/src/Box2DBindings/Stats.cs
+++ b/src/Box2DBindings/Stats.cs
@@ -14,7 +14,7 @@ public static class Stats
 
     static unsafe Stats()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2GetByteCount", out var ptr);
         b2GetByteCount = (delegate* unmanaged[Cdecl]<int>)ptr;
     }

--- a/src/Box2DBindings/SurfaceMaterial.cs
+++ b/src/Box2DBindings/SurfaceMaterial.cs
@@ -15,7 +15,7 @@ public struct SurfaceMaterial
 
     static unsafe SurfaceMaterial()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2DefaultSurfaceMaterial", out var ptr);
         b2DefaultSurfaceMaterial = (delegate* unmanaged[Cdecl]<SurfaceMaterial>)ptr;
     }

--- a/src/Box2DBindings/Sweep.cs
+++ b/src/Box2DBindings/Sweep.cs
@@ -17,7 +17,7 @@ public struct Sweep
 
     static unsafe Sweep()
     {
-        nint lib = NativeLibrary.Load(libraryName);
+        nint lib = Core.NativeLibHandle;
         NativeLibrary.TryGetExport(lib, "b2GetSweepTransform", out var ptr);
         b2GetSweepTransform = (delegate* unmanaged[Cdecl]<in Sweep, float, Transform>)ptr;
     }

--- a/src/Box2DBindings/World.cs
+++ b/src/Box2DBindings/World.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NET9_0_OR_GREATER
 using System.Threading;
@@ -113,6 +114,7 @@ public sealed partial class World
     /// <summary>
     /// Destroy this world
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void Destroy()
     {
         if (!Valid) return;

--- a/src/Box2DBindings/World_Externs.cs
+++ b/src/Box2DBindings/World_Externs.cs
@@ -94,7 +94,7 @@ partial class World
     
     static unsafe World()
     {
-        var lib = NativeLibrary.Load(libraryName);
+        var lib = Core.NativeLibHandle;
 
         NativeLibrary.TryGetExport(lib, "b2World_IsValid", out var p0);
         NativeLibrary.TryGetExport(lib, "b2World_Step", out var p1);


### PR DESCRIPTION
## Summary
- centralize the native library handle in `Core`
- rent buffers for body enumerations
- inline small comparers and cleanup destructors
- pre-size `ConcurrentHashSet` buckets

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults` *(fails: Failed: 32, Passed: 4, Skipped: 0, Total: 36, Duration: 75 ms)*