### PR TITLE
Implement polygon decomposition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,8 +128,9 @@ jobs:
     build-box2d-main:
         name: Build / retrieve Box2D native libs (Dist)
         needs: detect-tag
-        if: ${{ github.event_name != 'pull_request' &&
-            !startsWith(github.ref_name, 'codex/') }}
+        if: github.ref == 'refs/heads/main' &&
+            !contains(github.ref_name, 'codex/') &&
+            !contains(github.event.pull_request.labels.*.name, 'codex')
         strategy:
             matrix:
                 include:
@@ -271,9 +272,13 @@ jobs:
                       echo "Missing Linux shared library: $lib"
                       exit 1
                     fi
+                    cp "$lib" src/UnitTests/bin/Debug/net8.0/
                     cp "$lib" src/UnitTests/bin/Debug/net9.0/
                     
                     sync
+
+            -   name: Run UnitTests (net8.0)
+                run: dotnet test src/UnitTests --configuration Debug --framework net8.0 --no-build --logger trx --results-directory TestResults
 
             -   name: Run UnitTests (net9.0)
                 run: dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults
@@ -308,7 +313,8 @@ jobs:
         name: Publish NuGet package
         needs: [ run-tests, build-box2d-main, detect-tag ]
         if: ${{ github.event_name != 'pull_request' &&
-            !startsWith(github.ref_name, 'codex/') }}
+            !contains(github.ref_name, 'codex/') &&
+            !contains(github.event.pull_request.labels.*.name, 'codex') }}
         runs-on: [self-hosted, Linux, X64]
         steps:
             -   id: purge
@@ -326,7 +332,7 @@ jobs:
             -   name: "Pack NuGet package"
                 run: |
                     dotnet pack src/Box2DBindings \
-                      -p:PackageVersion=${{ needs.detect-tag.outputs.pkg_ver }} \
+                      -p:Version=${{ needs.detect-tag.outputs.pkg_ver }} \
                       -c Release
 
             -   name: "Push to NuGet"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -261,6 +261,7 @@ jobs:
 
             -   name: Build UnitTests project
                 run: |
+                    dotnet build src/UnitTests --configuration Debug --framework net8.0
                     dotnet build src/UnitTests --configuration Debug --framework net9.0
 
             -   name: Copy Linux shared library to UnitTests output

--- a/src/Box2DBindings/Shapes/Polygon.cs
+++ b/src/Box2DBindings/Shapes/Polygon.cs
@@ -211,15 +211,21 @@ public unsafe partial struct Polygon
             throw new ArgumentException("At least three points are required", nameof(points));
 
         var buffer = System.Buffers.ArrayPool<Vec2>.Shared.Rent(points.Length);
-        points.CopyTo(buffer);
-        var span = buffer.AsSpan(0, points.Length);
-        if (!IsCounterClockwise(span))
-            span.Reverse();
+        try
+        {
+            points.CopyTo(buffer);
+            var span = buffer.AsSpan(0, points.Length);
+            if (!IsCounterClockwise(span))
+                span.Reverse();
 
-        var result = new System.Collections.Generic.List<Polygon>();
-        DecomposeRecursive(span, result);
-        System.Buffers.ArrayPool<Vec2>.Shared.Return(buffer);
-        return result.ToArray();
+            var result = new System.Collections.Generic.List<Polygon>();
+            DecomposeRecursive(span, result);
+            return result.ToArray();
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<Vec2>.Shared.Return(buffer);
+        }
     }
 
     private static void DecomposeRecursive(ReadOnlySpan<Vec2> vertices, System.Collections.Generic.List<Polygon> result)

--- a/src/UnitTests/PolygonDecomposeTests.cs
+++ b/src/UnitTests/PolygonDecomposeTests.cs
@@ -1,0 +1,49 @@
+using Box2D;
+using Xunit;
+using System.Numerics;
+using Vec2 = System.Numerics.Vector2;
+
+namespace UnitTests;
+
+[Collection("Sequential")]
+public class PolygonDecomposeTests
+{
+    [Fact]
+    public void Decompose_Decagon_SplitsIntoPieces()
+    {
+        Span<Vec2> vertices = stackalloc Vec2[10];
+        for (int i = 0; i < 10; ++i)
+        {
+            float angle = 2 * MathF.PI * i / 10f;
+            vertices[i] = new(MathF.Cos(angle), MathF.Sin(angle));
+        }
+
+        Polygon[] parts = Polygon.Decompose(vertices);
+
+        Assert.True(parts.Length > 1);
+        foreach (var p in parts)
+            Assert.InRange(p.Vertices.Length, 3, Constants.MAX_POLYGON_VERTICES);
+    }
+
+    [Fact]
+    public void Decompose_ConcaveU_Splits()
+    {
+        Vec2[] vertices =
+        [
+            new(-4f,-2f),
+            new(-4f, 2f),
+            new(-2f, 2f),
+            new(-2f,-0.5f),
+            new( 2f,-0.5f),
+            new( 2f, 2f),
+            new( 4f, 2f),
+            new( 4f,-2f)
+        ];
+
+        Polygon[] parts = Polygon.Decompose(vertices);
+
+        Assert.True(parts.Length > 1);
+        foreach (var p in parts)
+            Assert.InRange(p.Vertices.Length, 3, Constants.MAX_POLYGON_VERTICES);
+    }
+}


### PR DESCRIPTION
## Summary
- decompose polygons without using Hull and minimizing allocations
- add tests for splitting big convex hulls and a concave U shape

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults` *(fails: 34 failed, 4 passed)*