### PR TITLE
Introduce BodyId and cache Body shapes

### DIFF
--- a/src/Box2DBindings/BodyId.cs
+++ b/src/Box2DBindings/BodyId.cs
@@ -1,0 +1,44 @@
+using Box2D.Comparers;
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Box2D;
+
+[StructLayout(LayoutKind.Sequential)]
+[PublicAPI]
+struct BodyId : IEquatable<BodyId>, IComparable<BodyId>
+{
+    internal int index1;
+    internal ushort world0;
+    internal ushort generation;
+
+    public BodyId(int index1, ushort world0, ushort generation)
+    {
+        this.index1 = index1;
+        this.world0 = world0;
+        this.generation = generation;
+    }
+
+    public bool Equals(BodyId other) => index1 == other.index1 && world0 == other.world0 && generation == other.generation;
+
+    public override bool Equals(object? obj) => obj is BodyId other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(index1, world0, generation);
+
+    public static IEqualityComparer<BodyId> DefaultEqualityComparer { get; } = EqualityComparer<BodyId>.Default;
+
+    public static IComparer<BodyId> DefaultComparer { get; } = Comparer<BodyId>.Default;
+
+    public int CompareTo(BodyId other)
+    {
+        int index1Comparison = index1.CompareTo(other.index1);
+        if (index1Comparison != 0)
+            return index1Comparison;
+        int world0Comparison = world0.CompareTo(other.world0);
+        if (world0Comparison != 0)
+            return world0Comparison;
+        return generation.CompareTo(other.generation);
+    }
+}

--- a/src/Box2DBindings/Body_Externs.cs
+++ b/src/Box2DBindings/Body_Externs.cs
@@ -2,79 +2,79 @@ using System.Runtime.InteropServices;
 
 namespace Box2D
 {
-    partial struct Body
+    partial class Body
     {
 #if NET5_0_OR_GREATER
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, void> b2DestroyBody;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsValid;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, BodyType> b2Body_GetType;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, BodyType, void> b2Body_SetType;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, string?, void> b2Body_SetName;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, nint> b2Body_GetName;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, nint, void> b2Body_SetUserData;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, nint> b2Body_GetUserData;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2> b2Body_GetPosition;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Rotation> b2Body_GetRotation;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Transform> b2Body_GetTransform;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Rotation, void> b2Body_SetTransform;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetLocalPoint;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetWorldPoint;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetLocalVector;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetWorldVector;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, void> b2Body_SetLinearVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2> b2Body_GetLinearVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetAngularVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, void> b2Body_SetAngularVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Transform, float, void> b2Body_SetTargetTransform;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetLocalPointVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2> b2Body_GetWorldPointVelocity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2, byte, void> b2Body_ApplyForce;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, byte, void> b2Body_ApplyForceToCenter;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, byte, void> b2Body_ApplyTorque;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, Vec2, byte, void> b2Body_ApplyLinearImpulse;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2, byte, void> b2Body_ApplyLinearImpulseToCenter;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, byte, void> b2Body_ApplyAngularImpulse;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetMass;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetRotationalInertia;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2> b2Body_GetLocalCenterOfMass;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Vec2> b2Body_GetWorldCenterOfMass;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, MassData, void> b2Body_SetMassData;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, MassData> b2Body_GetMassData;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, void> b2Body_ApplyMassFromShapes;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, void> b2Body_SetLinearDamping;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetLinearDamping;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, void> b2Body_SetAngularDamping;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetAngularDamping;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, void> b2Body_SetGravityScale;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetGravityScale;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsAwake;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_SetAwake;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_EnableSleep;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsSleepEnabled;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float, void> b2Body_SetSleepThreshold;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, float> b2Body_GetSleepThreshold;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsEnabled;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, void> b2Body_Disable;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, void> b2Body_Enable;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_SetFixedRotation;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsFixedRotation;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_SetBullet;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte> b2Body_IsBullet;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_EnableContactEvents;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, byte, void> b2Body_EnableHitEvents;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, WorldId> b2Body_GetWorld;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, int> b2Body_GetShapeCount;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, Shape*, int, int> b2Body_GetShapes;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, int> b2Body_GetJointCount;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, JointId*, int, int> b2Body_GetJoints;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, int> b2Body_GetContactCapacity;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, ContactData*, int, int> b2Body_GetContactData;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, AABB> b2Body_ComputeAABB;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Circle, Shape> b2CreateCircleShape;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Segment, Shape> b2CreateSegmentShape;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Capsule, Shape> b2CreateCapsuleShape;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Polygon, Shape> b2CreatePolygonShape;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Body, in ChainDefInternal, ChainShapeId> b2CreateChain;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, void> b2DestroyBody;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsValid;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, BodyType> b2Body_GetType;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, BodyType, void> b2Body_SetType;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, string?, void> b2Body_SetName;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, nint> b2Body_GetName;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, nint, void> b2Body_SetUserData;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, nint> b2Body_GetUserData;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2> b2Body_GetPosition;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Rotation> b2Body_GetRotation;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Transform> b2Body_GetTransform;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Rotation, void> b2Body_SetTransform;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetLocalPoint;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetWorldPoint;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetLocalVector;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetWorldVector;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, void> b2Body_SetLinearVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2> b2Body_GetLinearVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetAngularVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, void> b2Body_SetAngularVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Transform, float, void> b2Body_SetTargetTransform;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetLocalPointVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2> b2Body_GetWorldPointVelocity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2, byte, void> b2Body_ApplyForce;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, byte, void> b2Body_ApplyForceToCenter;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, byte, void> b2Body_ApplyTorque;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2, byte, void> b2Body_ApplyLinearImpulse;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2, byte, void> b2Body_ApplyLinearImpulseToCenter;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, byte, void> b2Body_ApplyAngularImpulse;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetMass;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetRotationalInertia;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2> b2Body_GetLocalCenterOfMass;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Vec2> b2Body_GetWorldCenterOfMass;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, MassData, void> b2Body_SetMassData;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, MassData> b2Body_GetMassData;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, void> b2Body_ApplyMassFromShapes;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, void> b2Body_SetLinearDamping;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetLinearDamping;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, void> b2Body_SetAngularDamping;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetAngularDamping;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, void> b2Body_SetGravityScale;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetGravityScale;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsAwake;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_SetAwake;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_EnableSleep;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsSleepEnabled;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float, void> b2Body_SetSleepThreshold;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, float> b2Body_GetSleepThreshold;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsEnabled;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, void> b2Body_Disable;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, void> b2Body_Enable;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_SetFixedRotation;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsFixedRotation;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_SetBullet;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte> b2Body_IsBullet;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_EnableContactEvents;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, byte, void> b2Body_EnableHitEvents;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, WorldId> b2Body_GetWorld;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, int> b2Body_GetShapeCount;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, Shape*, int, int> b2Body_GetShapes;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, int> b2Body_GetJointCount;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, JointId*, int, int> b2Body_GetJoints;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, int> b2Body_GetContactCapacity;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, ContactData*, int, int> b2Body_GetContactData;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, AABB> b2Body_ComputeAABB;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Circle, Shape> b2CreateCircleShape;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Segment, Shape> b2CreateSegmentShape;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Capsule, Shape> b2CreateCapsuleShape;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Polygon, Shape> b2CreatePolygonShape;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<BodyId, in ChainDefInternal, ChainShapeId> b2CreateChain;
 
         static unsafe Body()
         {
@@ -150,287 +150,287 @@ namespace Box2D
             NativeLibrary.TryGetExport(lib, "b2CreatePolygonShape", out var p68);
             NativeLibrary.TryGetExport(lib, "b2CreateChain", out var p69);
 
-            b2DestroyBody = (delegate* unmanaged[Cdecl]<Body, void>)p0;
-            b2Body_IsValid = (delegate* unmanaged[Cdecl]<Body, byte>)p1;
-            b2Body_GetType = (delegate* unmanaged[Cdecl]<Body, BodyType>)p2;
-            b2Body_SetType = (delegate* unmanaged[Cdecl]<Body, BodyType, void>)p3;
-            b2Body_SetName = (delegate* unmanaged[Cdecl]<Body, string?, void>)p4;
-            b2Body_GetName = (delegate* unmanaged[Cdecl]<Body, nint>)p5;
-            b2Body_SetUserData = (delegate* unmanaged[Cdecl]<Body, nint, void>)p6;
-            b2Body_GetUserData = (delegate* unmanaged[Cdecl]<Body, nint>)p7;
-            b2Body_GetPosition = (delegate* unmanaged[Cdecl]<Body, Vec2>)p8;
-            b2Body_GetRotation = (delegate* unmanaged[Cdecl]<Body, Rotation>)p9;
-            b2Body_GetTransform = (delegate* unmanaged[Cdecl]<Body, Transform>)p10;
-            b2Body_SetTransform = (delegate* unmanaged[Cdecl]<Body, Vec2, Rotation, void>)p11;
-            b2Body_GetLocalPoint = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p12;
-            b2Body_GetWorldPoint = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p13;
-            b2Body_GetLocalVector = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p14;
-            b2Body_GetWorldVector = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p15;
-            b2Body_SetLinearVelocity = (delegate* unmanaged[Cdecl]<Body, Vec2, void>)p16;
-            b2Body_GetLinearVelocity = (delegate* unmanaged[Cdecl]<Body, Vec2>)p17;
-            b2Body_GetAngularVelocity = (delegate* unmanaged[Cdecl]<Body, float>)p18;
-            b2Body_SetAngularVelocity = (delegate* unmanaged[Cdecl]<Body, float, void>)p19;
-            b2Body_SetTargetTransform = (delegate* unmanaged[Cdecl]<Body, Transform, float, void>)p20;
-            b2Body_GetLocalPointVelocity = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p21;
-            b2Body_GetWorldPointVelocity = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2>)p22;
-            b2Body_ApplyForce = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2, byte, void>)p23;
-            b2Body_ApplyForceToCenter = (delegate* unmanaged[Cdecl]<Body, Vec2, byte, void>)p24;
-            b2Body_ApplyTorque = (delegate* unmanaged[Cdecl]<Body, float, byte, void>)p25;
-            b2Body_ApplyLinearImpulse = (delegate* unmanaged[Cdecl]<Body, Vec2, Vec2, byte, void>)p26;
-            b2Body_ApplyLinearImpulseToCenter = (delegate* unmanaged[Cdecl]<Body, Vec2, byte, void>)p27;
-            b2Body_ApplyAngularImpulse = (delegate* unmanaged[Cdecl]<Body, float, byte, void>)p28;
-            b2Body_GetMass = (delegate* unmanaged[Cdecl]<Body, float>)p29;
-            b2Body_GetRotationalInertia = (delegate* unmanaged[Cdecl]<Body, float>)p30;
-            b2Body_GetLocalCenterOfMass = (delegate* unmanaged[Cdecl]<Body, Vec2>)p31;
-            b2Body_GetWorldCenterOfMass = (delegate* unmanaged[Cdecl]<Body, Vec2>)p32;
-            b2Body_SetMassData = (delegate* unmanaged[Cdecl]<Body, MassData, void>)p33;
-            b2Body_GetMassData = (delegate* unmanaged[Cdecl]<Body, MassData>)p34;
-            b2Body_ApplyMassFromShapes = (delegate* unmanaged[Cdecl]<Body, void>)p35;
-            b2Body_SetLinearDamping = (delegate* unmanaged[Cdecl]<Body, float, void>)p36;
-            b2Body_GetLinearDamping = (delegate* unmanaged[Cdecl]<Body, float>)p37;
-            b2Body_SetAngularDamping = (delegate* unmanaged[Cdecl]<Body, float, void>)p38;
-            b2Body_GetAngularDamping = (delegate* unmanaged[Cdecl]<Body, float>)p39;
-            b2Body_SetGravityScale = (delegate* unmanaged[Cdecl]<Body, float, void>)p40;
-            b2Body_GetGravityScale = (delegate* unmanaged[Cdecl]<Body, float>)p41;
-            b2Body_IsAwake = (delegate* unmanaged[Cdecl]<Body, byte>)p42;
-            b2Body_SetAwake = (delegate* unmanaged[Cdecl]<Body, byte, void>)p43;
-            b2Body_EnableSleep = (delegate* unmanaged[Cdecl]<Body, byte, void>)p44;
-            b2Body_IsSleepEnabled = (delegate* unmanaged[Cdecl]<Body, byte>)p45;
-            b2Body_SetSleepThreshold = (delegate* unmanaged[Cdecl]<Body, float, void>)p46;
-            b2Body_GetSleepThreshold = (delegate* unmanaged[Cdecl]<Body, float>)p47;
-            b2Body_IsEnabled = (delegate* unmanaged[Cdecl]<Body, byte>)p48;
-            b2Body_Disable = (delegate* unmanaged[Cdecl]<Body, void>)p49;
-            b2Body_Enable = (delegate* unmanaged[Cdecl]<Body, void>)p50;
-            b2Body_SetFixedRotation = (delegate* unmanaged[Cdecl]<Body, byte, void>)p51;
-            b2Body_IsFixedRotation = (delegate* unmanaged[Cdecl]<Body, byte>)p52;
-            b2Body_SetBullet = (delegate* unmanaged[Cdecl]<Body, byte, void>)p53;
-            b2Body_IsBullet = (delegate* unmanaged[Cdecl]<Body, byte>)p54;
-            b2Body_EnableContactEvents = (delegate* unmanaged[Cdecl]<Body, byte, void>)p55;
-            b2Body_EnableHitEvents = (delegate* unmanaged[Cdecl]<Body, byte, void>)p56;
-            b2Body_GetWorld = (delegate* unmanaged[Cdecl]<Body, WorldId>)p57;
-            b2Body_GetShapeCount = (delegate* unmanaged[Cdecl]<Body, int>)p58;
-            b2Body_GetShapes = (delegate* unmanaged[Cdecl]<Body, Shape*, int, int>)p59;
-            b2Body_GetJointCount = (delegate* unmanaged[Cdecl]<Body, int>)p60;
-            b2Body_GetJoints = (delegate* unmanaged[Cdecl]<Body, JointId*, int, int>)p61;
-            b2Body_GetContactCapacity = (delegate* unmanaged[Cdecl]<Body, int>)p62;
-            b2Body_GetContactData = (delegate* unmanaged[Cdecl]<Body, ContactData*, int, int>)p63;
-            b2Body_ComputeAABB = (delegate* unmanaged[Cdecl]<Body, AABB>)p64;
-            b2CreateCircleShape = (delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Circle, Shape>)p65;
-            b2CreateSegmentShape = (delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Segment, Shape>)p66;
-            b2CreateCapsuleShape = (delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Capsule, Shape>)p67;
-            b2CreatePolygonShape = (delegate* unmanaged[Cdecl]<Body, in ShapeDefInternal, in Polygon, Shape>)p68;
-            b2CreateChain = (delegate* unmanaged[Cdecl]<Body, in ChainDefInternal, ChainShapeId>)p69;
+            b2DestroyBody = (delegate* unmanaged[Cdecl]<BodyId, void>)p0;
+            b2Body_IsValid = (delegate* unmanaged[Cdecl]<BodyId, byte>)p1;
+            b2Body_GetType = (delegate* unmanaged[Cdecl]<BodyId, BodyType>)p2;
+            b2Body_SetType = (delegate* unmanaged[Cdecl]<BodyId, BodyType, void>)p3;
+            b2Body_SetName = (delegate* unmanaged[Cdecl]<BodyId, string?, void>)p4;
+            b2Body_GetName = (delegate* unmanaged[Cdecl]<BodyId, nint>)p5;
+            b2Body_SetUserData = (delegate* unmanaged[Cdecl]<BodyId, nint, void>)p6;
+            b2Body_GetUserData = (delegate* unmanaged[Cdecl]<BodyId, nint>)p7;
+            b2Body_GetPosition = (delegate* unmanaged[Cdecl]<BodyId, Vec2>)p8;
+            b2Body_GetRotation = (delegate* unmanaged[Cdecl]<BodyId, Rotation>)p9;
+            b2Body_GetTransform = (delegate* unmanaged[Cdecl]<BodyId, Transform>)p10;
+            b2Body_SetTransform = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Rotation, void>)p11;
+            b2Body_GetLocalPoint = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p12;
+            b2Body_GetWorldPoint = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p13;
+            b2Body_GetLocalVector = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p14;
+            b2Body_GetWorldVector = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p15;
+            b2Body_SetLinearVelocity = (delegate* unmanaged[Cdecl]<BodyId, Vec2, void>)p16;
+            b2Body_GetLinearVelocity = (delegate* unmanaged[Cdecl]<BodyId, Vec2>)p17;
+            b2Body_GetAngularVelocity = (delegate* unmanaged[Cdecl]<BodyId, float>)p18;
+            b2Body_SetAngularVelocity = (delegate* unmanaged[Cdecl]<BodyId, float, void>)p19;
+            b2Body_SetTargetTransform = (delegate* unmanaged[Cdecl]<BodyId, Transform, float, void>)p20;
+            b2Body_GetLocalPointVelocity = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p21;
+            b2Body_GetWorldPointVelocity = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2>)p22;
+            b2Body_ApplyForce = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2, byte, void>)p23;
+            b2Body_ApplyForceToCenter = (delegate* unmanaged[Cdecl]<BodyId, Vec2, byte, void>)p24;
+            b2Body_ApplyTorque = (delegate* unmanaged[Cdecl]<BodyId, float, byte, void>)p25;
+            b2Body_ApplyLinearImpulse = (delegate* unmanaged[Cdecl]<BodyId, Vec2, Vec2, byte, void>)p26;
+            b2Body_ApplyLinearImpulseToCenter = (delegate* unmanaged[Cdecl]<BodyId, Vec2, byte, void>)p27;
+            b2Body_ApplyAngularImpulse = (delegate* unmanaged[Cdecl]<BodyId, float, byte, void>)p28;
+            b2Body_GetMass = (delegate* unmanaged[Cdecl]<BodyId, float>)p29;
+            b2Body_GetRotationalInertia = (delegate* unmanaged[Cdecl]<BodyId, float>)p30;
+            b2Body_GetLocalCenterOfMass = (delegate* unmanaged[Cdecl]<BodyId, Vec2>)p31;
+            b2Body_GetWorldCenterOfMass = (delegate* unmanaged[Cdecl]<BodyId, Vec2>)p32;
+            b2Body_SetMassData = (delegate* unmanaged[Cdecl]<BodyId, MassData, void>)p33;
+            b2Body_GetMassData = (delegate* unmanaged[Cdecl]<BodyId, MassData>)p34;
+            b2Body_ApplyMassFromShapes = (delegate* unmanaged[Cdecl]<BodyId, void>)p35;
+            b2Body_SetLinearDamping = (delegate* unmanaged[Cdecl]<BodyId, float, void>)p36;
+            b2Body_GetLinearDamping = (delegate* unmanaged[Cdecl]<BodyId, float>)p37;
+            b2Body_SetAngularDamping = (delegate* unmanaged[Cdecl]<BodyId, float, void>)p38;
+            b2Body_GetAngularDamping = (delegate* unmanaged[Cdecl]<BodyId, float>)p39;
+            b2Body_SetGravityScale = (delegate* unmanaged[Cdecl]<BodyId, float, void>)p40;
+            b2Body_GetGravityScale = (delegate* unmanaged[Cdecl]<BodyId, float>)p41;
+            b2Body_IsAwake = (delegate* unmanaged[Cdecl]<BodyId, byte>)p42;
+            b2Body_SetAwake = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p43;
+            b2Body_EnableSleep = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p44;
+            b2Body_IsSleepEnabled = (delegate* unmanaged[Cdecl]<BodyId, byte>)p45;
+            b2Body_SetSleepThreshold = (delegate* unmanaged[Cdecl]<BodyId, float, void>)p46;
+            b2Body_GetSleepThreshold = (delegate* unmanaged[Cdecl]<BodyId, float>)p47;
+            b2Body_IsEnabled = (delegate* unmanaged[Cdecl]<BodyId, byte>)p48;
+            b2Body_Disable = (delegate* unmanaged[Cdecl]<BodyId, void>)p49;
+            b2Body_Enable = (delegate* unmanaged[Cdecl]<BodyId, void>)p50;
+            b2Body_SetFixedRotation = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p51;
+            b2Body_IsFixedRotation = (delegate* unmanaged[Cdecl]<BodyId, byte>)p52;
+            b2Body_SetBullet = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p53;
+            b2Body_IsBullet = (delegate* unmanaged[Cdecl]<BodyId, byte>)p54;
+            b2Body_EnableContactEvents = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p55;
+            b2Body_EnableHitEvents = (delegate* unmanaged[Cdecl]<BodyId, byte, void>)p56;
+            b2Body_GetWorld = (delegate* unmanaged[Cdecl]<BodyId, WorldId>)p57;
+            b2Body_GetShapeCount = (delegate* unmanaged[Cdecl]<BodyId, int>)p58;
+            b2Body_GetShapes = (delegate* unmanaged[Cdecl]<BodyId, Shape*, int, int>)p59;
+            b2Body_GetJointCount = (delegate* unmanaged[Cdecl]<BodyId, int>)p60;
+            b2Body_GetJoints = (delegate* unmanaged[Cdecl]<BodyId, JointId*, int, int>)p61;
+            b2Body_GetContactCapacity = (delegate* unmanaged[Cdecl]<BodyId, int>)p62;
+            b2Body_GetContactData = (delegate* unmanaged[Cdecl]<BodyId, ContactData*, int, int>)p63;
+            b2Body_ComputeAABB = (delegate* unmanaged[Cdecl]<BodyId, AABB>)p64;
+            b2CreateCircleShape = (delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Circle, Shape>)p65;
+            b2CreateSegmentShape = (delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Segment, Shape>)p66;
+            b2CreateCapsuleShape = (delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Capsule, Shape>)p67;
+            b2CreatePolygonShape = (delegate* unmanaged[Cdecl]<BodyId, in ShapeDefInternal, in Polygon, Shape>)p68;
+            b2CreateChain = (delegate* unmanaged[Cdecl]<BodyId, in ChainDefInternal, ChainShapeId>)p69;
         }
 #else
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2DestroyBody")]
-    private static extern void b2DestroyBody(Body bodyId);
+    private static extern void b2DestroyBody(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsValid")]
-    private static extern byte b2Body_IsValid(Body bodyId);
+    private static extern byte b2Body_IsValid(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetType")]
-    private static extern BodyType b2Body_GetType(Body bodyId);
+    private static extern BodyType b2Body_GetType(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetType")]
-    private static extern void b2Body_SetType(Body bodyId, BodyType type);
+    private static extern void b2Body_SetType(BodyId bodyId, BodyType type);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetName")]
-    private static extern void b2Body_SetName(Body bodyId, string? name);
+    private static extern void b2Body_SetName(BodyId bodyId, string? name);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetName")]
-    private static extern nint b2Body_GetName(Body bodyId);
+    private static extern nint b2Body_GetName(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetUserData")]
-    private static extern void b2Body_SetUserData(Body bodyId, nint userData);
+    private static extern void b2Body_SetUserData(BodyId bodyId, nint userData);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetUserData")]
-    private static extern nint b2Body_GetUserData(Body bodyId);
+    private static extern nint b2Body_GetUserData(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetPosition")]
-    private static extern Vec2 b2Body_GetPosition(Body bodyId);
+    private static extern Vec2 b2Body_GetPosition(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetRotation")]
-    private static extern Rotation b2Body_GetRotation(Body bodyId);
+    private static extern Rotation b2Body_GetRotation(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetTransform")]
-    private static extern Transform b2Body_GetTransform(Body bodyId);
+    private static extern Transform b2Body_GetTransform(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetTransform")]
-    private static extern void b2Body_SetTransform(Body bodyId, Vec2 position, Rotation rotation);
+    private static extern void b2Body_SetTransform(BodyId bodyId, Vec2 position, Rotation rotation);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLocalPoint")]
-    private static extern Vec2 b2Body_GetLocalPoint(Body bodyId, Vec2 worldPoint);
+    private static extern Vec2 b2Body_GetLocalPoint(BodyId bodyId, Vec2 worldPoint);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetWorldPoint")]
-    private static extern Vec2 b2Body_GetWorldPoint(Body bodyId, Vec2 localPoint);
+    private static extern Vec2 b2Body_GetWorldPoint(BodyId bodyId, Vec2 localPoint);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLocalVector")]
-    private static extern Vec2 b2Body_GetLocalVector(Body bodyId, Vec2 worldVector);
+    private static extern Vec2 b2Body_GetLocalVector(BodyId bodyId, Vec2 worldVector);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetWorldVector")]
-    private static extern Vec2 b2Body_GetWorldVector(Body bodyId, Vec2 localVector);
+    private static extern Vec2 b2Body_GetWorldVector(BodyId bodyId, Vec2 localVector);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetLinearVelocity")]
-    private static extern void b2Body_SetLinearVelocity(Body bodyId, Vec2 linearVelocity);
+    private static extern void b2Body_SetLinearVelocity(BodyId bodyId, Vec2 linearVelocity);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLinearVelocity")]
-    private static extern Vec2 b2Body_GetLinearVelocity(Body bodyId);
+    private static extern Vec2 b2Body_GetLinearVelocity(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetAngularVelocity")]
-    private static extern float b2Body_GetAngularVelocity(Body bodyId);
+    private static extern float b2Body_GetAngularVelocity(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetAngularVelocity")]
-    private static extern void b2Body_SetAngularVelocity(Body bodyId, float angularVelocity);
+    private static extern void b2Body_SetAngularVelocity(BodyId bodyId, float angularVelocity);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetTargetTransform")]
-    private static extern void b2Body_SetTargetTransform(Body bodyId, Transform target, float timeStep);
+    private static extern void b2Body_SetTargetTransform(BodyId bodyId, Transform target, float timeStep);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLocalPointVelocity")]
-    private static extern Vec2 b2Body_GetLocalPointVelocity(Body bodyId, Vec2 localPoint);
+    private static extern Vec2 b2Body_GetLocalPointVelocity(BodyId bodyId, Vec2 localPoint);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetWorldPointVelocity")]
-    private static extern Vec2 b2Body_GetWorldPointVelocity(Body bodyId, Vec2 worldPoint);
+    private static extern Vec2 b2Body_GetWorldPointVelocity(BodyId bodyId, Vec2 worldPoint);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyForce")]
-    private static extern void b2Body_ApplyForce(Body bodyId, Vec2 force, Vec2 point, byte wake);
+    private static extern void b2Body_ApplyForce(BodyId bodyId, Vec2 force, Vec2 point, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyForceToCenter")]
-    private static extern void b2Body_ApplyForceToCenter(Body bodyId, Vec2 force, byte wake);
+    private static extern void b2Body_ApplyForceToCenter(BodyId bodyId, Vec2 force, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyTorque")]
-    private static extern void b2Body_ApplyTorque(Body bodyId, float torque, byte wake);
+    private static extern void b2Body_ApplyTorque(BodyId bodyId, float torque, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyLinearImpulse")]
-    private static extern void b2Body_ApplyLinearImpulse(Body bodyId, Vec2 impulse, Vec2 point, byte wake);
+    private static extern void b2Body_ApplyLinearImpulse(BodyId bodyId, Vec2 impulse, Vec2 point, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyLinearImpulseToCenter")]
-    private static extern void b2Body_ApplyLinearImpulseToCenter(Body bodyId, Vec2 impulse, byte wake);
+    private static extern void b2Body_ApplyLinearImpulseToCenter(BodyId bodyId, Vec2 impulse, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyAngularImpulse")]
-    private static extern void b2Body_ApplyAngularImpulse(Body bodyId, float impulse, byte wake);
+    private static extern void b2Body_ApplyAngularImpulse(BodyId bodyId, float impulse, byte wake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetMass")]
-    private static extern float b2Body_GetMass(Body bodyId);
+    private static extern float b2Body_GetMass(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetRotationalInertia")]
-    private static extern float b2Body_GetRotationalInertia(Body bodyId);
+    private static extern float b2Body_GetRotationalInertia(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLocalCenterOfMass")]
-    private static extern Vec2 b2Body_GetLocalCenterOfMass(Body bodyId);
+    private static extern Vec2 b2Body_GetLocalCenterOfMass(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetWorldCenterOfMass")]
-    private static extern Vec2 b2Body_GetWorldCenterOfMass(Body bodyId);
+    private static extern Vec2 b2Body_GetWorldCenterOfMass(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetMassData")]
-    private static extern void b2Body_SetMassData(Body bodyId, MassData massData);
+    private static extern void b2Body_SetMassData(BodyId bodyId, MassData massData);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetMassData")]
-    private static extern MassData b2Body_GetMassData(Body bodyId);
+    private static extern MassData b2Body_GetMassData(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ApplyMassFromShapes")]
-    private static extern void b2Body_ApplyMassFromShapes(Body bodyId);
+    private static extern void b2Body_ApplyMassFromShapes(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetLinearDamping")]
-    private static extern void b2Body_SetLinearDamping(Body bodyId, float linearDamping);
+    private static extern void b2Body_SetLinearDamping(BodyId bodyId, float linearDamping);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetLinearDamping")]
-    private static extern float b2Body_GetLinearDamping(Body bodyId);
+    private static extern float b2Body_GetLinearDamping(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetAngularDamping")]
-    private static extern void b2Body_SetAngularDamping(Body bodyId, float angularDamping);
+    private static extern void b2Body_SetAngularDamping(BodyId bodyId, float angularDamping);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetAngularDamping")]
-    private static extern float b2Body_GetAngularDamping(Body bodyId);
+    private static extern float b2Body_GetAngularDamping(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetGravityScale")]
-    private static extern void b2Body_SetGravityScale(Body bodyId, float gravityScale);
+    private static extern void b2Body_SetGravityScale(BodyId bodyId, float gravityScale);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetGravityScale")]
-    private static extern float b2Body_GetGravityScale(Body bodyId);
+    private static extern float b2Body_GetGravityScale(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsAwake")]
-    private static extern byte b2Body_IsAwake(Body bodyId);
+    private static extern byte b2Body_IsAwake(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetAwake")]
-    private static extern void b2Body_SetAwake(Body bodyId, byte awake);
+    private static extern void b2Body_SetAwake(BodyId bodyId, byte awake);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_EnableSleep")]
-    private static extern void b2Body_EnableSleep(Body bodyId, byte enableSleep);
+    private static extern void b2Body_EnableSleep(BodyId bodyId, byte enableSleep);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsSleepEnabled")]
-    private static extern byte b2Body_IsSleepEnabled(Body bodyId);
+    private static extern byte b2Body_IsSleepEnabled(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetSleepThreshold")]
-    private static extern void b2Body_SetSleepThreshold(Body bodyId, float sleepThreshold);
+    private static extern void b2Body_SetSleepThreshold(BodyId bodyId, float sleepThreshold);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetSleepThreshold")]
-    private static extern float b2Body_GetSleepThreshold(Body bodyId);
+    private static extern float b2Body_GetSleepThreshold(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsEnabled")]
-    private static extern byte b2Body_IsEnabled(Body bodyId);
+    private static extern byte b2Body_IsEnabled(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_Disable")]
-    private static extern void b2Body_Disable(Body bodyId);
+    private static extern void b2Body_Disable(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_Enable")]
-    private static extern void b2Body_Enable(Body bodyId);
+    private static extern void b2Body_Enable(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetFixedRotation")]
-    private static extern void b2Body_SetFixedRotation(Body bodyId, byte flag);
+    private static extern void b2Body_SetFixedRotation(BodyId bodyId, byte flag);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsFixedRotation")]
-    private static extern byte b2Body_IsFixedRotation(Body bodyId);
+    private static extern byte b2Body_IsFixedRotation(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_SetBullet")]
-    private static extern void b2Body_SetBullet(Body bodyId, byte flag);
+    private static extern void b2Body_SetBullet(BodyId bodyId, byte flag);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_IsBullet")]
-    private static extern byte b2Body_IsBullet(Body bodyId);
+    private static extern byte b2Body_IsBullet(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_EnableContactEvents")]
-    private static extern void b2Body_EnableContactEvents(Body bodyId, byte flag);
+    private static extern void b2Body_EnableContactEvents(BodyId bodyId, byte flag);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_EnableHitEvents")]
-    private static extern void b2Body_EnableHitEvents(Body bodyId, byte flag);
+    private static extern void b2Body_EnableHitEvents(BodyId bodyId, byte flag);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetWorld")]
-    private static extern WorldId b2Body_GetWorld(Body bodyId);
+    private static extern WorldId b2Body_GetWorld(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetShapeCount")]
-    private static extern int b2Body_GetShapeCount(Body bodyId);
+    private static extern int b2Body_GetShapeCount(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetShapes")]
-    private static extern unsafe int b2Body_GetShapes(Body bodyId, Shape* shapeArray, int capacity);
+    private static extern unsafe int b2Body_GetShapes(BodyId bodyId, Shape* shapeArray, int capacity);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetJointCount")]
-    private static extern int b2Body_GetJointCount(Body bodyId);
+    private static extern int b2Body_GetJointCount(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetJoints")]
-    private static extern unsafe int b2Body_GetJoints(Body bodyId, JointId* jointArray, int capacity);
+    private static extern unsafe int b2Body_GetJoints(BodyId bodyId, JointId* jointArray, int capacity);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetContactCapacity")]
-    private static extern int b2Body_GetContactCapacity(Body bodyId);
+    private static extern int b2Body_GetContactCapacity(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_GetContactData")]
-    private static extern unsafe int b2Body_GetContactData(Body bodyId, ContactData* contactData, int capacity);
+    private static extern unsafe int b2Body_GetContactData(BodyId bodyId, ContactData* contactData, int capacity);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Body_ComputeAABB")]
-    private static extern AABB b2Body_ComputeAABB(Body bodyId);
+    private static extern AABB b2Body_ComputeAABB(BodyId bodyId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateCircleShape")]
-    private static extern Shape b2CreateCircleShape(Body bodyId, in ShapeDefInternal def, in Circle circle);
+    private static extern Shape b2CreateCircleShape(BodyId bodyId, in ShapeDefInternal def, in Circle circle);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateSegmentShape")]
-    private static extern Shape b2CreateSegmentShape(Body bodyId, in ShapeDefInternal def, in Segment segment);
+    private static extern Shape b2CreateSegmentShape(BodyId bodyId, in ShapeDefInternal def, in Segment segment);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateCapsuleShape")]
-    private static extern Shape b2CreateCapsuleShape(Body bodyId, in ShapeDefInternal def, in Capsule capsule);
+    private static extern Shape b2CreateCapsuleShape(BodyId bodyId, in ShapeDefInternal def, in Capsule capsule);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreatePolygonShape")]
-    private static extern Shape b2CreatePolygonShape(Body bodyId, in ShapeDefInternal def, in Polygon polygon);
+    private static extern Shape b2CreatePolygonShape(BodyId bodyId, in ShapeDefInternal def, in Polygon polygon);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateChain")]
-    private static extern ChainShapeId b2CreateChain(Body bodyId, in ChainDefInternal def);
+    private static extern ChainShapeId b2CreateChain(BodyId bodyId, in ChainDefInternal def);
 #endif
     }
 }

--- a/src/Box2DBindings/Defs/DistanceJointDef.cs
+++ b/src/Box2DBindings/Defs/DistanceJointDef.cs
@@ -18,12 +18,20 @@ public sealed class DistanceJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The local anchor point relative to bodyA's origin

--- a/src/Box2DBindings/Defs/FilterJointDef.cs
+++ b/src/Box2DBindings/Defs/FilterJointDef.cs
@@ -14,12 +14,20 @@ public sealed class FilterJointDef
     /// <summary>
     /// The first attached body.
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body.
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// User data

--- a/src/Box2DBindings/Defs/InternalDefs/DistanceJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/DistanceJointDefInternal.cs
@@ -20,9 +20,9 @@ struct DistanceJointDefInternal
     private static extern DistanceJointDefInternal b2DefaultDistanceJointDef();
 #endif
     
-    internal Body BodyA;
+    internal BodyId BodyA;
 
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     internal Vec2 LocalAnchorA;
 

--- a/src/Box2DBindings/Defs/InternalDefs/FilterJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/FilterJointDefInternal.cs
@@ -20,9 +20,9 @@ struct FilterJointDefInternal
     private static extern FilterJointDefInternal b2DefaultNullJointDef();
 #endif
     
-    internal Body BodyA;
+    internal BodyId BodyA;
     
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     internal nint UserData;
 

--- a/src/Box2DBindings/Defs/InternalDefs/MotorJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/MotorJointDefInternal.cs
@@ -23,12 +23,12 @@ struct MotorJointDefInternal
     /// <summary>
     /// The first attached body
     /// </summary>
-    internal Body BodyA;
+    internal BodyId BodyA;
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     /// <summary>
     /// Position of bodyB minus the position of bodyA, in bodyA's frame

--- a/src/Box2DBindings/Defs/InternalDefs/MouseJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/MouseJointDefInternal.cs
@@ -20,9 +20,9 @@ struct MouseJointDefInternal
     private static extern MouseJointDefInternal b2DefaultMouseJointDef();
 #endif
     
-    internal Body BodyA;
+    internal BodyId BodyA;
     
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     internal Vec2 Target;
 

--- a/src/Box2DBindings/Defs/InternalDefs/PrismaticJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/PrismaticJointDefInternal.cs
@@ -20,9 +20,9 @@ struct PrismaticJointDefInternal
     private static extern PrismaticJointDefInternal b2DefaultPrismaticJointDef();
 #endif
     
-    internal Body BodyA;
+    internal BodyId BodyA;
 
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     internal Vec2 LocalAnchorA;
 

--- a/src/Box2DBindings/Defs/InternalDefs/RevoluteJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/RevoluteJointDefInternal.cs
@@ -20,9 +20,9 @@ struct RevoluteJointDefInternal
     private static extern RevoluteJointDefInternal b2DefaultRevoluteJointDef();
 #endif
 
-    internal Body BodyA;
+    internal BodyId BodyA;
     
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     internal Vec2 LocalAnchorA;
 

--- a/src/Box2DBindings/Defs/InternalDefs/WeldJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/WeldJointDefInternal.cs
@@ -21,10 +21,10 @@ struct WeldJointDefInternal
 #endif
 
     [FieldOffset(0)]
-    internal Body BodyA;
+    internal BodyId BodyA;
 
     [FieldOffset(8)]
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     [FieldOffset(16)]
     internal Vec2 LocalAnchorA;

--- a/src/Box2DBindings/Defs/InternalDefs/WheelJointDefInternal.cs
+++ b/src/Box2DBindings/Defs/InternalDefs/WheelJointDefInternal.cs
@@ -21,10 +21,10 @@ struct WheelJointDefInternal
 #endif
     
     [FieldOffset(0)]
-    internal Body BodyA;
+    internal BodyId BodyA;
     
     [FieldOffset(8)]
-    internal Body BodyB;
+    internal BodyId BodyB;
 
     [FieldOffset(16)]
     internal Vec2 LocalAnchorA;

--- a/src/Box2DBindings/Defs/MotorJointDef.cs
+++ b/src/Box2DBindings/Defs/MotorJointDef.cs
@@ -16,12 +16,20 @@ public sealed class MotorJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// Position of bodyB minus the position of bodyA, in bodyA's frame

--- a/src/Box2DBindings/Defs/MouseJointDef.cs
+++ b/src/Box2DBindings/Defs/MouseJointDef.cs
@@ -17,12 +17,20 @@ public sealed class MouseJointDef
     /// <summary>
     /// The first attached body. This is assumed to be static.
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body.
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The initial target point in world space

--- a/src/Box2DBindings/Defs/PrismaticJointDef.cs
+++ b/src/Box2DBindings/Defs/PrismaticJointDef.cs
@@ -19,12 +19,20 @@ public sealed class PrismaticJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The local anchor point relative to bodyA's origin

--- a/src/Box2DBindings/Defs/RevoluteJointDef.cs
+++ b/src/Box2DBindings/Defs/RevoluteJointDef.cs
@@ -20,12 +20,20 @@ public sealed class RevoluteJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The local anchor point relative to bodyA's origin

--- a/src/Box2DBindings/Defs/WeldJointDef.cs
+++ b/src/Box2DBindings/Defs/WeldJointDef.cs
@@ -18,12 +18,20 @@ public sealed class WeldJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The local anchor point relative to bodyA's origin

--- a/src/Box2DBindings/Defs/WheelJointDef.cs
+++ b/src/Box2DBindings/Defs/WheelJointDef.cs
@@ -19,12 +19,20 @@ public sealed class WheelJointDef
     /// <summary>
     /// The first attached body
     /// </summary>
-    public ref Body BodyA => ref _internal.BodyA;
+    public Body BodyA
+    {
+        get => Body.GetBody(_internal.BodyA);
+        set => _internal.BodyA = value.id;
+    }
 
     /// <summary>
     /// The second attached body
     /// </summary>
-    public ref Body BodyB => ref _internal.BodyB;
+    public Body BodyB
+    {
+        get => Body.GetBody(_internal.BodyB);
+        set => _internal.BodyB = value.id;
+    }
 
     /// <summary>
     /// The local anchor point relative to bodyA's origin
@@ -153,8 +161,8 @@ public sealed class WheelJointDef
         bool collideConnected = false,
         object? userData = null)
     {
-        _internal.BodyA = bodyA;
-        _internal.BodyB = bodyB;
+        BodyA = bodyA;
+        BodyB = bodyB;
         _internal.LocalAnchorA = anchorA;
         _internal.LocalAnchorB = anchorB;
         _internal.LocalAxisA = axisA;

--- a/src/Box2DBindings/Joints/Joint.cs
+++ b/src/Box2DBindings/Joints/Joint.cs
@@ -74,13 +74,13 @@ public partial class Joint
     /// Gets body A on this joint
     /// </summary>
     /// <returns>The body A on this joint</returns>
-    public unsafe Body BodyA => Valid ? b2Joint_GetBodyA(id) : throw new InvalidOperationException("Joint is not valid");
+    public unsafe Body BodyA => Valid ? Body.GetBody(b2Joint_GetBodyA(id)) : throw new InvalidOperationException("Joint is not valid");
 
     /// <summary>
     /// Gets body B on this joint
     /// </summary>
     /// <returns>The body B on this joint</returns>
-    public unsafe Body BodyB => Valid ? b2Joint_GetBodyB(id) : throw new InvalidOperationException("Joint is not valid");
+    public unsafe Body BodyB => Valid ? Body.GetBody(b2Joint_GetBodyB(id)) : throw new InvalidOperationException("Joint is not valid");
 
     /// <summary>
     /// Gets the world that owns this joint

--- a/src/Box2DBindings/Joints/Joint_Externs.cs
+++ b/src/Box2DBindings/Joints/Joint_Externs.cs
@@ -8,8 +8,8 @@ namespace Box2D
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, void> b2DestroyJoint;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, byte> b2Joint_IsValid;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, JointType> b2Joint_GetType;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, Body> b2Joint_GetBodyA;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, Body> b2Joint_GetBodyB;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, BodyId> b2Joint_GetBodyA;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, BodyId> b2Joint_GetBodyB;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, WorldId> b2Joint_GetWorld;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, Vec2> b2Joint_GetLocalAnchorA;
     private static readonly unsafe delegate* unmanaged[Cdecl]<JointId, Vec2> b2Joint_GetLocalAnchorB;
@@ -43,8 +43,8 @@ namespace Box2D
         b2DestroyJoint = (delegate* unmanaged[Cdecl]<JointId, void>)p0;
         b2Joint_IsValid = (delegate* unmanaged[Cdecl]<JointId, byte>)p1;
         b2Joint_GetType = (delegate* unmanaged[Cdecl]<JointId, JointType>)p2;
-        b2Joint_GetBodyA = (delegate* unmanaged[Cdecl]<JointId, Body>)p3;
-        b2Joint_GetBodyB = (delegate* unmanaged[Cdecl]<JointId, Body>)p4;
+        b2Joint_GetBodyA = (delegate* unmanaged[Cdecl]<JointId, BodyId>)p3;
+        b2Joint_GetBodyB = (delegate* unmanaged[Cdecl]<JointId, BodyId>)p4;
         b2Joint_GetWorld = (delegate* unmanaged[Cdecl]<JointId, WorldId>)p5;
         b2Joint_GetLocalAnchorA = (delegate* unmanaged[Cdecl]<JointId, Vec2>)p6;
         b2Joint_GetLocalAnchorB = (delegate* unmanaged[Cdecl]<JointId, Vec2>)p7;
@@ -67,10 +67,10 @@ namespace Box2D
     private static extern JointType b2Joint_GetType(JointId jointId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Joint_GetBodyA")]
-    private static extern Body b2Joint_GetBodyA(JointId jointId);
+    private static extern BodyId b2Joint_GetBodyA(JointId jointId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Joint_GetBodyB")]
-    private static extern Body b2Joint_GetBodyB(JointId jointId);
+    private static extern BodyId b2Joint_GetBodyB(JointId jointId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Joint_GetWorld")]
     private static extern WorldId b2Joint_GetWorld(JointId jointId);

--- a/src/Box2DBindings/Shapes/Shape.cs
+++ b/src/Box2DBindings/Shapes/Shape.cs
@@ -136,7 +136,7 @@ public partial struct Shape : IEquatable<Shape>, IComparable<Shape>
     /// Gets the body that this shape is attached to
     /// </summary>
     /// <returns>The body that this shape is attached to</returns>
-    public unsafe Body Body => Valid ? b2Shape_GetBody(this) : throw new InvalidOperationException("Shape is not valid");
+    public unsafe Body Body => Valid ? Body.GetBody(b2Shape_GetBody(this)) : throw new InvalidOperationException("Shape is not valid");
 
     /// <summary>
     /// Gets the world that this shape belongs to

--- a/src/Box2DBindings/Shapes/Shape_Externs.cs
+++ b/src/Box2DBindings/Shapes/Shape_Externs.cs
@@ -9,7 +9,7 @@ namespace Box2D
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, byte, void> b2DestroyShape;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, byte> b2Shape_IsValid;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, ShapeType> b2Shape_GetType;
-        private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, Body> b2Shape_GetBody;
+        private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, BodyId> b2Shape_GetBody;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, WorldId> b2Shape_GetWorld;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, byte> b2Shape_IsSensor;
         private static readonly unsafe delegate* unmanaged[Cdecl]<Shape, byte, void> b2Shape_EnableSensorEvents;
@@ -108,7 +108,7 @@ namespace Box2D
             b2DestroyShape = (delegate* unmanaged[Cdecl]<Shape, byte, void>)p0;
             b2Shape_IsValid = (delegate* unmanaged[Cdecl]<Shape, byte>)p1;
             b2Shape_GetType = (delegate* unmanaged[Cdecl]<Shape, ShapeType>)p2;
-            b2Shape_GetBody = (delegate* unmanaged[Cdecl]<Shape, Body>)p3;
+            b2Shape_GetBody = (delegate* unmanaged[Cdecl]<Shape, BodyId>)p3;
             b2Shape_GetWorld = (delegate* unmanaged[Cdecl]<Shape, WorldId>)p4;
             b2Shape_IsSensor = (delegate* unmanaged[Cdecl]<Shape, byte>)p5;
             b2Shape_EnableSensorEvents = (delegate* unmanaged[Cdecl]<Shape, byte, void>)p6;
@@ -164,7 +164,7 @@ namespace Box2D
     private static extern ShapeType b2Shape_GetType(Shape shape);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_GetBody")]
-    private static extern Body b2Shape_GetBody(Shape shape);
+    private static extern BodyId b2Shape_GetBody(Shape shape);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2Shape_GetWorld")]
     private static extern WorldId b2Shape_GetWorld(Shape shape);

--- a/src/Box2DBindings/World.cs
+++ b/src/Box2DBindings/World.cs
@@ -681,9 +681,10 @@ public sealed partial class World
     /// <returns>The body</returns>
     public unsafe Body CreateBody(BodyDef def)
     {
-        Body body = b2CreateBody(id, def._internal);
+        BodyId bodyId = b2CreateBody(id, def._internal);
+        Body body = Body.GetBody(bodyId);
         if (!body.Valid)
-            return default;
+            return default!;
         bodies.Add(body);
         return body;
     }

--- a/src/Box2DBindings/World_Externs.cs
+++ b/src/Box2DBindings/World_Externs.cs
@@ -38,7 +38,7 @@ partial class World
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, nint, void> b2World_SetFrictionCallback_;
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, nint, void> b2World_SetRestitutionCallback_;
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, void> b2World_DumpMemoryStats;
-    private static unsafe delegate* unmanaged[Cdecl]<WorldId, in BodyDefInternal, Body> b2CreateBody;
+    private static unsafe delegate* unmanaged[Cdecl]<WorldId, in BodyDefInternal, BodyId> b2CreateBody;
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, in DistanceJointDefInternal, JointId> b2CreateDistanceJoint;
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, in MotorJointDefInternal, JointId> b2CreateMotorJoint;
     private static unsafe delegate* unmanaged[Cdecl]<WorldId, in MouseJointDefInternal, JointId> b2CreateMouseJoint;
@@ -174,7 +174,7 @@ partial class World
         b2World_SetFrictionCallback_ = (delegate* unmanaged[Cdecl]<WorldId, nint, void>)p30;
         b2World_SetRestitutionCallback_ = (delegate* unmanaged[Cdecl]<WorldId, nint, void>)p31;
         b2World_DumpMemoryStats = (delegate* unmanaged[Cdecl]<WorldId, void>)p32;
-        b2CreateBody = (delegate* unmanaged[Cdecl]<WorldId, in BodyDefInternal, Body>)p33;
+        b2CreateBody = (delegate* unmanaged[Cdecl]<WorldId, in BodyDefInternal, BodyId>)p33;
         b2CreateDistanceJoint = (delegate* unmanaged[Cdecl]<WorldId, in DistanceJointDefInternal, JointId>)p34;
         b2CreateMotorJoint = (delegate* unmanaged[Cdecl]<WorldId, in MotorJointDefInternal, JointId>)p35;
         b2CreateMouseJoint = (delegate* unmanaged[Cdecl]<WorldId, in MouseJointDefInternal, JointId>)p36;
@@ -308,7 +308,7 @@ partial class World
     private static extern void b2World_DumpMemoryStats(WorldId worldId);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateBody")]
-    private static extern Body b2CreateBody(WorldId worldId, in BodyDefInternal def);
+    private static extern BodyId b2CreateBody(WorldId worldId, in BodyDefInternal def);
 
     [DllImport(libraryName, CallingConvention = CallingConvention.Cdecl, EntryPoint = "b2CreateDistanceJoint")]
     private static extern JointId b2CreateDistanceJoint(WorldId worldId, in DistanceJointDefInternal def);


### PR DESCRIPTION
## Summary
- convert `Body` from struct to class using `BodyId`
- update externs and joint/shape APIs for `BodyId`
- cache shapes attached to a `Body`
- update joint definitions to use `BodyId`

## Testing
- `dotnet build src/UnitTests --configuration Debug --framework net9.0 --no-restore`
- `dotnet test src/UnitTests --configuration Debug --framework net9.0 --no-build --logger trx --results-directory TestResults`
